### PR TITLE
Fix for regression in 4.x caused by usage of javax.imageio.ImageIO

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.twelvemonkeys.imageio</groupId>
+            <artifactId>imageio-jpeg</artifactId>
+            <version>3.0-rc5</version>
+        </dependency>
+        <dependency>
             <groupId>net.sf.saxon</groupId>
             <artifactId>Saxon-HE</artifactId>
             <version>9.5.1-5</version>


### PR DESCRIPTION
Added [com.twelvemonkeys.imageio](https://github.com/haraldk/TwelveMonkeys) to maven dependencies to [broaden JPEG support](https://github.com/haraldk/TwelveMonkeys#jpeg) when using ImageIO. It is automatically registered by the ImageIO registry and service lookup mechanisms. Fixes IDPF/epubcheck#464.