### PR TITLE
Make the test pass on Java 8 and offline

### DIFF
--- a/src/main/java/com/adobe/epubcheck/ctc/css/EpubCSSCheckCSSHandler.java
+++ b/src/main/java/com/adobe/epubcheck/ctc/css/EpubCSSCheckCSSHandler.java
@@ -3,6 +3,7 @@ package com.adobe.epubcheck.ctc.css;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
@@ -97,7 +98,7 @@ public class EpubCSSCheckCSSHandler implements CssContentHandler, CssErrorHandle
     public int Count;
   }
 
-  HashMap<String, ClassUsage> classMap = new HashMap<String, ClassUsage>();
+  HashMap<String, ClassUsage> classMap = new LinkedHashMap<String, ClassUsage>();
 
   public EpubCSSCheckCSSHandler(Report report, boolean isGlobalFixedFormat, boolean hasIndividualFixedFormatDocuments)
   {

--- a/src/main/java/com/adobe/epubcheck/ctc/xml/CSSStyleAttributeHandler.java
+++ b/src/main/java/com/adobe/epubcheck/ctc/xml/CSSStyleAttributeHandler.java
@@ -1,10 +1,13 @@
 package com.adobe.epubcheck.ctc.xml;
 
-import com.adobe.epubcheck.api.Report;
-import com.adobe.epubcheck.ctc.css.EpubCSSCheckCSSHandler;
-import com.adobe.epubcheck.messages.MessageId;
-import com.adobe.epubcheck.messages.MessageLocation;
-import com.adobe.epubcheck.util.LocationImpl;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Stack;
+import java.util.Vector;
+
 import org.idpf.epubcheck.util.css.CssParser;
 import org.idpf.epubcheck.util.css.CssSource;
 import org.xml.sax.Attributes;
@@ -12,12 +15,11 @@ import org.xml.sax.Locator;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
 
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Stack;
-import java.util.Vector;
+import com.adobe.epubcheck.api.Report;
+import com.adobe.epubcheck.ctc.css.EpubCSSCheckCSSHandler;
+import com.adobe.epubcheck.messages.MessageId;
+import com.adobe.epubcheck.messages.MessageLocation;
+import com.adobe.epubcheck.util.LocationImpl;
 
 public class CSSStyleAttributeHandler extends DefaultHandler
 {
@@ -28,7 +30,7 @@ public class CSSStyleAttributeHandler extends DefaultHandler
   private boolean isGlobalFixedFormat = false;
   private boolean documentIsFixedFormat = false;
   private CSSStyleAttributeHandler.StyleAttribute currentStyleTag = null;
-  private final HashMap<String, StyleAttribute> styleAttributesValues = new HashMap<String, StyleAttribute>();
+  private final HashMap<String, StyleAttribute> styleAttributesValues = new LinkedHashMap<String, StyleAttribute>();
   private final Stack<HashMap<String, EpubCSSCheckCSSHandler.ClassUsage>> localStyles = new Stack<HashMap<String, EpubCSSCheckCSSHandler.ClassUsage>>();
   private final Stack<Integer> styleLevels = new Stack<Integer>();
   private EpubCSSCheckCSSHandler cssHandler;
@@ -117,7 +119,7 @@ public class CSSStyleAttributeHandler extends DefaultHandler
     tagStack.push(qName.toLowerCase());
     if (qName.compareToIgnoreCase("style") == 0)
     {
-      HashMap<String, EpubCSSCheckCSSHandler.ClassUsage> localStyleMap = new HashMap<String, EpubCSSCheckCSSHandler.ClassUsage>();
+      HashMap<String, EpubCSSCheckCSSHandler.ClassUsage> localStyleMap = new LinkedHashMap<String, EpubCSSCheckCSSHandler.ClassUsage>();
       localStyles.push(localStyleMap);
       this.styleLevels.push(tagStack.size() - 1); // we are pushing the depth of the style's PARENT node here, not the depth of the STYLE node
 

--- a/src/main/java/com/adobe/epubcheck/ocf/OCFZipPackage.java
+++ b/src/main/java/com/adobe/epubcheck/ocf/OCFZipPackage.java
@@ -1,10 +1,5 @@
 package com.adobe.epubcheck.ocf;
 
-import com.adobe.epubcheck.api.Report;
-import com.adobe.epubcheck.messages.MessageId;
-import com.adobe.epubcheck.messages.MessageLocation;
-import com.adobe.epubcheck.util.FeatureEnum;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -15,8 +10,14 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
+
+import com.adobe.epubcheck.api.Report;
+import com.adobe.epubcheck.messages.MessageId;
+import com.adobe.epubcheck.messages.MessageLocation;
+import com.adobe.epubcheck.util.FeatureEnum;
 
 public class OCFZipPackage extends OCFPackage
 {
@@ -38,8 +39,8 @@ public class OCFZipPackage extends OCFPackage
     synchronized (zip)
     {
       allEntries = new LinkedList<String>();
-      fileEntries = new HashSet<String>();
-      dirEntries = new HashSet<String>();
+      fileEntries = new TreeSet<String>();
+      dirEntries = new TreeSet<String>();
 
       try
       {
@@ -137,15 +138,6 @@ public class OCFZipPackage extends OCFPackage
       if (allEntries == null)
       {
         listEntries();
-      }
-      HashSet<String> entryNames = new HashSet<String>();
-      for (Enumeration<? extends ZipEntry> entries = zip.entries(); entries.hasMoreElements(); )
-      {
-        ZipEntry entry = entries.nextElement();
-        if (!entry.isDirectory())
-        {
-          entryNames.add(entry.getName());
-        }
       }
       return Collections.unmodifiableSet(fileEntries);
     }

--- a/src/main/java/com/adobe/epubcheck/reporting/ItemMetadata.java
+++ b/src/main/java/com/adobe/epubcheck/reporting/ItemMetadata.java
@@ -1,10 +1,12 @@
 package com.adobe.epubcheck.reporting;
 
-import com.adobe.epubcheck.util.FeatureEnum;
+import java.util.Map;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
 import org.codehaus.jackson.annotate.JsonProperty;
 
-import java.util.HashSet;
-import java.util.Map;
+import com.adobe.epubcheck.util.FeatureEnum;
 
 @SuppressWarnings("FieldCanBeLocal")
 public class ItemMetadata implements Comparable<ItemMetadata>
@@ -51,7 +53,7 @@ public class ItemMetadata implements Comparable<ItemMetadata>
   private String renditionSpread;
   @SuppressWarnings("MismatchedQueryAndUpdateOfCollection")
   @JsonProperty
-  private final HashSet<String> referencedItems = new HashSet<String>();
+  private final SortedSet<String> referencedItems = new TreeSet<String>();
 
   public static ItemMetadata getItemByName(Map<String, ItemMetadata> metadata, String fileName)
   {

--- a/src/main/java/com/adobe/epubcheck/xml/XMLParser.java
+++ b/src/main/java/com/adobe/epubcheck/xml/XMLParser.java
@@ -22,6 +22,39 @@
 
 package com.adobe.epubcheck.xml;
 
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Set;
+import java.util.Vector;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+
+import org.xml.sax.Attributes;
+import org.xml.sax.ContentHandler;
+import org.xml.sax.DTDHandler;
+import org.xml.sax.InputSource;
+import org.xml.sax.Locator;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXNotRecognizedException;
+import org.xml.sax.SAXNotSupportedException;
+import org.xml.sax.SAXParseException;
+import org.xml.sax.XMLReader;
+import org.xml.sax.ext.DeclHandler;
+import org.xml.sax.ext.LexicalHandler;
+import org.xml.sax.ext.Locator2;
+import org.xml.sax.helpers.AttributesImpl;
+import org.xml.sax.helpers.DefaultHandler;
+
 import com.adobe.epubcheck.api.Report;
 import com.adobe.epubcheck.messages.MessageId;
 import com.adobe.epubcheck.messages.MessageLocation;
@@ -31,20 +64,6 @@ import com.adobe.epubcheck.util.ResourceUtil;
 import com.thaiopensource.util.PropertyMapBuilder;
 import com.thaiopensource.validate.ValidateProperty;
 import com.thaiopensource.validate.Validator;
-
-import org.xml.sax.*;
-import org.xml.sax.ext.DeclHandler;
-import org.xml.sax.ext.LexicalHandler;
-import org.xml.sax.ext.Locator2;
-import org.xml.sax.helpers.AttributesImpl;
-import org.xml.sax.helpers.DefaultHandler;
-
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.parsers.SAXParser;
-import javax.xml.parsers.SAXParserFactory;
-
-import java.io.*;
-import java.util.*;
 
 public class XMLParser extends DefaultHandler implements LexicalHandler, DeclHandler
 {
@@ -1014,6 +1033,8 @@ public void startPrefixMapping(String arg0, String arg1)
         ResourceUtil.getResourcePath("schema/20/dtd/oebpkg12.dtd"));
     map.put("http://openebook.org/dtds/oeb-1.2/oeb12.ent",
         ResourceUtil.getResourcePath("schema/20/dtd/oeb12.dtdinc"));
+    map.put("http://openebook.org/dtds/oeb-1.2/oebdoc12.dtd",
+        ResourceUtil.getResourcePath("schema/20/dtd/oebdoc12.dtd"));
 
     //2.0 dtd, probably never published
     map.put("http://www.idpf.org/dtds/2007/opf.dtd",

--- a/src/main/resources/com/adobe/epubcheck/schema/20/dtd/oebdoc12.dtd
+++ b/src/main/resources/com/adobe/epubcheck/schema/20/dtd/oebdoc12.dtd
@@ -1,0 +1,555 @@
+<!--
+
+Title:
+
+     The Basic Document Type Definition (DTD) for the Open eBook
+     Publication Structure Version 1.2
+
+
+Version:
+
+     1.2
+
+
+Revision:
+
+     20020930-x  (supercedes 20020327-x)
+
+
+Revision History Note:
+
+     This revision, 20020930-x, corrects a very minor and subtle error
+     discovered in revision 20020327-x shortly after the as-yet-
+     unannounced release (on 27 August 2002) of OEBPS Version 1.2. The
+     error: the FIXED attribute assignment of the XHTML namespace to
+     the root <html> element using an entity reference was improperly
+     done, thus violating XML 1.0 rules (this error was incorrectly
+     carried over from the modular XHTML 1.1 DTD which this DTD
+     subsets.) Since many XML parsers do not even recognize this
+     subtle error, and it has no impact on the validity of authored
+     Basic OEBPS 1.2 Documents, it was determined that this error
+     could be corrected with the issuance of this revised DTD without
+     needing to update the version or release date of the Publication
+     Structure Specification itself. This revised DTD also includes an
+     email address update in this comment prologue. No other changes
+     were made to the parsed content of this DTD.
+
+
+Authors:
+
+     Jon Noring <jon@noring.name>
+
+
+Usage:
+
+     <?xml version="1.0"?>
+     <!DOCTYPE html PUBLIC
+          "+//ISBN 0-9673008-1-9//DTD OEB 1.2 Document//EN"
+          "http://openebook.org/dtds/oeb-1.2/oebdoc12.dtd">
+     <html>
+     ...
+     </html>
+
+
+Summary:
+
+     This DTD is a pure subset of XHTML 1.1: any document validating
+     to this DTD will also validate to the XHTML 1.1 DTD.
+
+-->
+
+
+<!-- *************************************************** -->
+
+<!-- GENERAL NOTATIONS ................................. -->
+
+<!-- W3C XML 1.0 Recommendation -->
+
+<!NOTATION w3c-xml
+     PUBLIC "ISO 8879//NOTATION Extensible Markup Language (XML) 1.0//EN">
+
+<!-- XML 1.0 CDATA -->
+
+<!NOTATION cdata
+     PUBLIC "-//W3C//NOTATION XML 1.0: CDATA//EN">
+
+<!-- *************************************************** -->
+
+<!-- ENTITIES WITH DATATYPE NOTATIONS .................. -->
+
+<!-- Content type, as per [RFC2045] -->
+
+<!NOTATION contentType
+    PUBLIC "-//W3C//NOTATION XHTML Datatype: ContentType//EN">
+<!ENTITY % ContentType.datatype "CDATA">
+
+<!-- Date and time information. ISO date format -->
+
+<!NOTATION datetime
+    PUBLIC "-//W3C//NOTATION XHTML Datatype: Datetime//EN">
+<!ENTITY % Datetime.datatype "CDATA">
+
+<!-- Language code, as per [RFC3066] -->
+
+<!NOTATION languageCode
+    PUBLIC "-//W3C//NOTATION XHTML Datatype: LanguageCode//EN">
+<!ENTITY % LanguageCode.datatype "NMTOKEN">
+
+<!-- Length defined for cellpadding/cellspacing -->
+<!-- nn for pixels or nn% for percentage length -->
+
+<!NOTATION length
+    PUBLIC "-//W3C//NOTATION XHTML Datatype: Length//EN">
+<!ENTITY % Length.datatype "CDATA">
+
+<!-- Space-separated list of link types -->
+
+<!NOTATION linkTypes
+    PUBLIC "-//W3C//NOTATION XHTML Datatype: LinkTypes//EN">
+<!ENTITY % LinkTypes.datatype "NMTOKENS">
+
+<!-- Single or comma-separated list of media descriptors -->
+
+<!NOTATION mediaDesc
+    PUBLIC "-//W3C//NOTATION XHTML Datatype: MediaDesc//EN">
+<!ENTITY % MediaDesc.datatype "CDATA">
+
+<!-- Pixel, percentage, or relative -->
+
+<!NOTATION multiLength
+    PUBLIC "-//W3C//NOTATION XHTML Datatype: MultiLength//EN">
+<!ENTITY % MultiLength.datatype "CDATA">
+
+<!-- One or more digits (NUMBER) -->
+
+<!NOTATION number
+    PUBLIC "-//W3C//NOTATION XHTML Datatype: Number//EN">
+<!ENTITY % Number.datatype "CDATA">
+
+<!-- Integer representing length in pixels -->
+
+<!NOTATION pixels
+    PUBLIC "-//W3C//NOTATION XHTML Datatype: Pixels//EN">
+<!ENTITY % Pixels.datatype "CDATA">
+
+<!-- Textual content -->
+
+<!NOTATION text
+    PUBLIC "-//W3C//NOTATION XHTML Datatype: Text//EN">
+<!ENTITY % Text.datatype "CDATA">
+
+<!-- Uniform Resource Identifier -->
+
+<!NOTATION uri
+    PUBLIC "-//W3C//NOTATION XHTML Datatype: URI//EN">
+<!ENTITY % URI.datatype "CDATA">
+
+<!-- Space-separated list of Uniform Resource Identifiers -->
+
+<!NOTATION uris
+    PUBLIC "-//W3C//NOTATION XHTML Datatype: URIs//EN">
+<!ENTITY % URIs.datatype "CDATA">
+
+<!-- *************************************************** -->
+
+<!-- ELEMENT ENTITIES .................................. -->
+
+<!ENTITY % Block.class
+     "address | blockquote | div | dl |
+      h1 | h2 | h3 | h4 | h5 | h6 |
+      hr | ol | p | pre | table | ul">
+
+<!ENTITY % Inline.class
+     "a | abbr | acronym | b | big | br |
+      cite | code | dfn | em | i | img | kbd |
+      map | object | q | samp | small | span |
+      strong | sub | sup | tt | var">
+
+<!ENTITY % BlockOrInline.class
+     "del | ins | noscript | script">
+
+<!ENTITY % Block.mix
+     "%Block.class; | %BlockOrInline.class;">
+
+<!ENTITY % Inline.mix
+     "%Inline.class; | %BlockOrInline.class;">
+
+<!ENTITY % Flow.mix
+     "%Block.class; | %Inline.class; | %BlockOrInline.class;">
+
+<!ENTITY % HeadOpts.mix
+     "(link | meta | object | script | style)*">
+
+<!-- *************************************************** -->
+
+<!-- ATTRIBUTE ENTITIES ................................ -->
+
+<!ENTITY % Core.attrib
+     "class        NMTOKENS                 #IMPLIED
+      id           ID                       #IMPLIED
+      style        CDATA                    #IMPLIED
+      title        %Text.datatype;          #IMPLIED">
+
+<!ENTITY % Common.attrib
+     "%Core.attrib;
+      xml:lang     %LanguageCode.datatype;  #IMPLIED">
+
+<!ENTITY % CellHAlign
+     "(left | center | right | justify)">
+
+<!ENTITY % CellVAlign
+     "(top | middle | bottom | baseline)">
+
+<!-- *************************************************** -->
+
+<!-- XHTML MNEMONIC CHARACTER ENTITIES ................. -->
+
+<!ENTITY % OEBEntities
+     PUBLIC "+//ISBN 0-9673008-1-9//DTD OEB 1.2 Entities//EN"
+     "http://openebook.org/dtds/oeb-1.2/oeb12.ent">
+
+%OEBEntities;
+
+<!-- *************************************************** -->
+
+<!-- ELEMENTS AND ATTRIBUTES ........................... -->
+
+<!-- TOP LEVEL STRUCTURE ............................... -->
+
+<!ELEMENT html (head, body)>
+<!ATTLIST html
+      xml:lang     %LanguageCode.datatype;  #IMPLIED
+      xmlns        %URI.datatype;           #FIXED 'http://www.w3.org/1999/xhtml'>
+
+<!ELEMENT head
+      ( %HeadOpts.mix;,
+        ( (title, %HeadOpts.mix;, (base,  %HeadOpts.mix;)?) |
+          (base,  %HeadOpts.mix;, (title, %HeadOpts.mix;) ) ) )>
+<!ATTLIST head
+      xml:lang     %LanguageCode.datatype;  #IMPLIED>
+
+<!ELEMENT body (%Block.mix;)+>
+<!ATTLIST body %Common.attrib;>
+
+<!-- HEAD LEVEL ........................................ -->
+
+<!ELEMENT base EMPTY>
+<!ATTLIST base
+      href         %URI.datatype;           #REQUIRED>
+
+<!ELEMENT link EMPTY>
+<!ATTLIST link
+      %Common.attrib;
+      href         %URI.datatype;           #IMPLIED
+      media        %MediaDesc.datatype;     #IMPLIED
+      rel          %LinkTypes.datatype;     #IMPLIED
+      rev          %LinkTypes.datatype;     #IMPLIED
+      type         %ContentType.datatype;   #IMPLIED>
+
+<!ELEMENT meta EMPTY>
+<!ATTLIST meta
+      content      CDATA                    #REQUIRED
+      name         NMTOKEN                  #IMPLIED
+      scheme       CDATA                    #IMPLIED
+      xml:lang     %LanguageCode.datatype;  #IMPLIED>
+
+<!ELEMENT style (#PCDATA)>
+<!ATTLIST style
+      title        %Text.datatype;          #IMPLIED
+      type         %ContentType.datatype;   #REQUIRED
+      xml:lang     %LanguageCode.datatype;  #IMPLIED
+      xml:space    (preserve)               #FIXED 'preserve'>
+
+<!ELEMENT title (#PCDATA)>
+<!ATTLIST title
+      xml:lang     %LanguageCode.datatype;  #IMPLIED>
+
+<!-- BLOCK LEVEL ....................................... -->
+
+<!ELEMENT address (#PCDATA | %Inline.mix;)*>
+<!ATTLIST address %Common.attrib;>
+
+<!ELEMENT blockquote (%Block.mix;)+>
+<!ATTLIST blockquote
+      %Common.attrib;
+      cite         %URI.datatype;           #IMPLIED>
+
+<!ELEMENT div (#PCDATA | %Flow.mix;)*>
+<!ATTLIST div %Common.attrib;>
+
+<!ELEMENT dl (dt | dd)+>
+<!ATTLIST dl %Common.attrib;>
+
+<!ELEMENT h1 (#PCDATA | %Inline.mix;)*>
+<!ATTLIST h1 %Common.attrib;>
+
+<!ELEMENT h2 (#PCDATA | %Inline.mix;)*>
+<!ATTLIST h2 %Common.attrib;>
+
+<!ELEMENT h3 (#PCDATA | %Inline.mix;)*>
+<!ATTLIST h3 %Common.attrib;>
+
+<!ELEMENT h4 (#PCDATA | %Inline.mix;)*>
+<!ATTLIST h4 %Common.attrib;>
+
+<!ELEMENT h5 (#PCDATA | %Inline.mix;)*>
+<!ATTLIST h5 %Common.attrib;>
+
+<!ELEMENT h6 (#PCDATA | %Inline.mix;)*>
+<!ATTLIST h6 %Common.attrib;>
+
+<!ELEMENT hr EMPTY>
+<!ATTLIST hr %Common.attrib;>
+
+<!ELEMENT ol (li)+>
+<!ATTLIST ol %Common.attrib;>
+
+<!ELEMENT p (#PCDATA | %Inline.mix;)*>
+<!ATTLIST p %Common.attrib;>
+
+<!ELEMENT pre
+      (#PCDATA |
+      a | abbr | acronym | b | br | cite |
+      code | dfn | em | i | kbd | map | q |
+      samp | span | strong | tt | var |
+      script)*>
+<!ATTLIST pre
+      %Common.attrib;
+      xml:space    (preserve)               #FIXED 'preserve'>
+
+<!ELEMENT table
+      ( caption?, (col* | colgroup*),
+        ( (thead?, tfoot?, tbody+) | (tr+) ) )>
+<!ATTLIST table
+      %Common.attrib;
+      border       %Pixels.datatype;        #IMPLIED
+      cellpadding  %Length.datatype;        #IMPLIED
+      cellspacing  %Length.datatype;        #IMPLIED
+      summary      %Text.datatype;          #IMPLIED
+      width        %Length.datatype;        #IMPLIED>
+
+<!ELEMENT ul (li)+>
+<!ATTLIST ul %Common.attrib;>
+
+<!-- INLINE LEVEL ...................................... -->
+
+<!ELEMENT a (#PCDATA |
+      abbr | acronym | b | big | br | cite |
+      code | dfn | em | i | img | kbd | map |
+      object | q | samp | small | span | strong |
+      sub | sup | tt | var |
+      %BlockOrInline.class;)*>
+<!ATTLIST a
+      %Common.attrib;
+      href         %URI.datatype;           #IMPLIED
+      rel          %LinkTypes.datatype;     #IMPLIED
+      rev          %LinkTypes.datatype;     #IMPLIED>
+
+<!ELEMENT abbr (#PCDATA | %Inline.mix;)*>
+<!ATTLIST abbr %Common.attrib;>
+
+<!ELEMENT acronym (#PCDATA | %Inline.mix;)*>
+<!ATTLIST acronym %Common.attrib;>
+
+<!ELEMENT b (#PCDATA | %Inline.mix;)*>
+<!ATTLIST b %Common.attrib;>
+
+<!ELEMENT big (#PCDATA | %Inline.mix;)*>
+<!ATTLIST big %Common.attrib;>
+
+<!ELEMENT br EMPTY>
+<!ATTLIST br %Core.attrib;>
+
+<!ELEMENT cite (#PCDATA | %Inline.mix;)*>
+<!ATTLIST cite %Common.attrib;>
+
+<!ELEMENT code (#PCDATA | %Inline.mix;)*>
+<!ATTLIST code %Common.attrib;>
+
+<!ELEMENT dfn (#PCDATA | %Inline.mix;)*>
+<!ATTLIST dfn %Common.attrib;>
+
+<!ELEMENT em (#PCDATA | %Inline.mix;)*>
+<!ATTLIST em %Common.attrib;>
+
+<!ELEMENT i (#PCDATA | %Inline.mix;)*>
+<!ATTLIST i %Common.attrib;>
+
+<!ELEMENT img EMPTY>
+<!ATTLIST img
+      %Common.attrib;
+      alt          %Text.datatype;          #REQUIRED
+      height       %Length.datatype;        #IMPLIED
+      longdesc     %URI.datatype;           #IMPLIED
+      src          %URI.datatype;           #REQUIRED
+      usemap       IDREF                    #IMPLIED
+      width        %Length.datatype;        #IMPLIED>
+
+<!ELEMENT kbd (#PCDATA | %Inline.mix;)*>
+<!ATTLIST kbd %Common.attrib;>
+
+<!ELEMENT map (%Block.mix; | area)+>
+<!ATTLIST map
+      class        NMTOKENS                 #IMPLIED
+      id           ID                       #REQUIRED
+      style        CDATA                    #IMPLIED
+      title        %Text.datatype;          #IMPLIED
+      xml:lang     %LanguageCode.datatype;  #IMPLIED>
+
+<!ELEMENT object (#PCDATA | %Flow.mix; | param)*>
+<!ATTLIST object
+      %Common.attrib;
+      archive      %URIs.datatype;          #IMPLIED
+      classid      %URI.datatype;           #IMPLIED
+      codebase     %URI.datatype;           #IMPLIED
+      codetype     %ContentType.datatype;   #IMPLIED
+      data         %URI.datatype;           #IMPLIED
+      height       %Length.datatype;        #IMPLIED
+      type         %ContentType.datatype;   #IMPLIED
+      usemap       IDREF                    #IMPLIED
+      width        %Length.datatype;        #IMPLIED>
+
+<!ELEMENT q (#PCDATA | %Inline.mix;)*>
+<!ATTLIST q
+      %Common.attrib;
+      cite         %URI.datatype;           #IMPLIED>
+
+<!ELEMENT samp (#PCDATA | %Inline.mix;)*>
+<!ATTLIST samp %Common.attrib;>
+
+<!ELEMENT small (#PCDATA | %Inline.mix;)*>
+<!ATTLIST small %Common.attrib;>
+
+<!ELEMENT span (#PCDATA | %Inline.mix;)*>
+<!ATTLIST span %Common.attrib;>
+
+<!ELEMENT strong (#PCDATA | %Inline.mix;)*>
+<!ATTLIST strong %Common.attrib;>
+
+<!ELEMENT sub (#PCDATA | %Inline.mix;)*>
+<!ATTLIST sub %Common.attrib;>
+
+<!ELEMENT sup (#PCDATA | %Inline.mix;)*>
+<!ATTLIST sup %Common.attrib;>
+
+<!ELEMENT tt (#PCDATA | %Inline.mix;)*>
+<!ATTLIST tt %Common.attrib;>
+
+<!ELEMENT var (#PCDATA | %Inline.mix;)*>
+<!ATTLIST var %Common.attrib;>
+
+<!-- BLOCK OR INLINE LEVEL ............................. -->
+
+<!ELEMENT del (#PCDATA | %Flow.mix;)*>
+<!ATTLIST del
+      %Common.attrib;
+      cite         %URI.datatype;           #IMPLIED
+      datetime     %Datetime.datatype;      #IMPLIED>
+
+<!ELEMENT ins (#PCDATA | %Flow.mix;)*>
+<!ATTLIST ins
+      %Common.attrib;
+      cite         %URI.datatype;           #IMPLIED
+      datetime     %Datetime.datatype;      #IMPLIED>
+
+<!ELEMENT noscript (%Block.mix;)+>
+<!ATTLIST noscript %Common.attrib;>
+
+<!ELEMENT script (#PCDATA)>
+<!ATTLIST script
+      type         %ContentType.datatype;   #REQUIRED
+      xml:space    (preserve)               #FIXED 'preserve'>
+
+<!-- TABLE LEVEL ....................................... -->
+
+<!ELEMENT caption (#PCDATA | %Inline.mix;)*>
+<!ATTLIST caption %Common.attrib;>
+
+<!ELEMENT col EMPTY>
+<!ATTLIST col
+      %Common.attrib;
+      align        %CellHAlign;             #IMPLIED
+      span         %Number.datatype;        '1'
+      valign       %CellVAlign;             #IMPLIED
+      width        %MultiLength.datatype;   #IMPLIED>
+
+<!ELEMENT colgroup (col)*>
+<!ATTLIST colgroup
+      %Common.attrib;
+      align        %CellHAlign;             #IMPLIED
+      span         %Number.datatype;        '1'
+      valign       %CellVAlign;             #IMPLIED
+      width        %MultiLength.datatype;   #IMPLIED>
+
+<!ELEMENT tbody (tr)+>
+<!ATTLIST tbody
+      %Common.attrib;
+      align        %CellHAlign;             #IMPLIED
+      valign       %CellVAlign;             #IMPLIED>
+
+<!ELEMENT td (#PCDATA | %Flow.mix;)*>
+<!ATTLIST td
+      %Common.attrib;
+      abbr         %Text.datatype;          #IMPLIED
+      align        %CellHAlign;             #IMPLIED
+      colspan      %Number.datatype;        '1'
+      rowspan      %Number.datatype;        '1'
+      valign       %CellVAlign;             #IMPLIED>
+
+<!ELEMENT tfoot (tr)+>
+<!ATTLIST tfoot
+      %Common.attrib;
+      align        %CellHAlign;             #IMPLIED
+      valign       %CellVAlign;             #IMPLIED>
+
+<!ELEMENT th (#PCDATA | %Flow.mix;)*>
+<!ATTLIST th
+      %Common.attrib;
+      abbr         %Text.datatype;          #IMPLIED
+      align        %CellHAlign;             #IMPLIED
+      colspan      %Number.datatype;        '1'
+      rowspan      %Number.datatype;        '1'
+      valign       %CellVAlign;             #IMPLIED>
+
+<!ELEMENT thead (tr)+>
+<!ATTLIST thead
+      %Common.attrib;
+      align        %CellHAlign;             #IMPLIED
+      valign       %CellVAlign;             #IMPLIED>
+
+<!ELEMENT tr (th | td)+>
+<!ATTLIST tr
+      %Common.attrib;
+      align        %CellHAlign;             #IMPLIED
+      valign       %CellVAlign;             #IMPLIED>
+
+<!-- LIST LEVEL ........................................ -->
+
+<!ELEMENT dd (#PCDATA | %Flow.mix;)*>
+<!ATTLIST dd %Common.attrib;>
+
+<!ELEMENT dt (#PCDATA | %Inline.mix;)*>
+<!ATTLIST dt %Common.attrib;>
+
+<!ELEMENT li (#PCDATA | %Flow.mix;)*>
+<!ATTLIST li %Common.attrib;>
+
+<!-- MISCELLANEOUS ..................................... -->
+
+<!ELEMENT area EMPTY>
+<!ATTLIST area
+      %Common.attrib;
+      alt          %Text.datatype;          #REQUIRED
+      coords       CDATA                    #IMPLIED
+      href         %URI.datatype;           #IMPLIED
+      nohref       (nohref)                 #IMPLIED
+      shape        (rect | circle |
+                    poly | default)         'rect'>
+
+<!ELEMENT param EMPTY>
+<!ATTLIST param
+      id           ID                       #IMPLIED
+      name         CDATA                    #REQUIRED
+      type         %ContentType.datatype;   #IMPLIED
+      value        CDATA                    #IMPLIED
+      valuetype    (data | ref | object)    'data'>

--- a/src/test/java/com/adobe/epubcheck/api/Epub30CheckTest.java
+++ b/src/test/java/com/adobe/epubcheck/api/Epub30CheckTest.java
@@ -277,9 +277,9 @@ public class Epub30CheckTest extends AbstractEpubCheckTest
 	public void testDuplicateZipEntriesIssue265b() {
     List<MessageId> expectedErrors = new ArrayList<MessageId>();
     List<MessageId> expectedWarnings = new ArrayList<MessageId>();
-    Collections.addAll(expectedWarnings, MessageId.PKG_012, MessageId.OPF_061, MessageId.OPF_003, MessageId.PKG_012);
+    Collections.addAll(expectedWarnings, MessageId.OPF_003, MessageId.PKG_012, MessageId.OPF_061, MessageId.PKG_012);
     // non-unique entry names (after NFC normalization) should raise a warning
-		testValidateDocument("invalid/issue265b.epub", expectedErrors, expectedWarnings);
+		testValidateDocument("invalid/issue265b.epub", expectedErrors, expectedWarnings, new ArrayList<MessageId>(), true);
 	}
 	
 	@Test

--- a/src/test/java/com/adobe/epubcheck/ops/OPSCheckerTest.java
+++ b/src/test/java/com/adobe/epubcheck/ops/OPSCheckerTest.java
@@ -473,7 +473,7 @@ public class OPSCheckerTest
   public void testValidateXHTML_UnresolvedDTD()
   {
     List<MessageId> expectedErrors = new ArrayList<MessageId>();
-    Collections.addAll(expectedErrors, MessageId.HTM_004, MessageId.RSC_001);
+    Collections.addAll(expectedErrors, MessageId.HTM_004);
     List<MessageId> expectedWarnings = new ArrayList<MessageId>();
     testValidateDocument("ops/invalid/unresolved-entity.xhtml",
         "application/xhtml+xml", expectedErrors, expectedWarnings, EPUBVersion.VERSION_2);

--- a/src/test/resources/20/single/ops/invalid/unresolved-entity.xhtml
+++ b/src/test/resources/20/single/ops/invalid/unresolved-entity.xhtml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1/EN" "http://idpf.org/xhtml11.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1/EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
 		<title>...</title>

--- a/src/test/resources/com/adobe/epubcheck/test/DTBook/Basic/OPS/AreYouReadyV3.xml
+++ b/src/test/resources/com/adobe/epubcheck/test/DTBook/Basic/OPS/AreYouReadyV3.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<!DOCTYPE dtbook PUBLIC "-//NISO//DTD dtbook 2005-3//EN" "http://www.daisy.org/z3986/2005/dtbook-2005-3.dtd">
+<!DOCTYPE dtbook PUBLIC "-//NISO//DTD dtbook 2005-3//EN" "http://www.daisy.org/z3986/2005/dtbook-2005-2.dtd">
 <?xml-stylesheet href="dtbookbasic.css" type="text/css"?>
 <dtbook xmlns="http://www.daisy.org/z3986/2005/dtbook/" version="2005-2" xml:lang="en-IN">
 	<head>

--- a/src/test/resources/com/adobe/epubcheck/test/DTBook/Basic_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/DTBook/Basic_expected_results.json
@@ -1,11 +1,11 @@
 {
   "customMessageFileName" : null,
   "checker" : {
-    "path" : "./com/adobe/epubcheck/test/DTBook/Basic.epub",
+    "path" : "./target/test-classes/com/adobe/epubcheck/test/DTBook/Basic.epub",
     "filename" : "Basic.epub",
-    "checkerVersion" : "4.0.0-alpha11-SNAPSHOT",
-    "checkDate" : "09-05-2014 03:16:21",
-    "elapsedTime" : 1431,
+    "checkerVersion" : "4.0.0-alpha12-SNAPSHOT",
+    "checkDate" : "03-25-2015 10:06:34",
+    "elapsedTime" : 1188,
     "nFatal" : 0,
     "nError" : 0,
     "nWarning" : 1,
@@ -126,7 +126,7 @@
     "renditionLayout" : null,
     "renditionOrientation" : null,
     "renditionSpread" : null,
-    "referencedItems" : [ "OPS/page01.xhtml", "OPS/AreYouReadyV3.xml" ]
+    "referencedItems" : [ "OPS/AreYouReadyV3.xml", "OPS/page01.xhtml" ]
   }, {
     "id" : "opf-36",
     "fileName" : "OPS/image1.jpg",
@@ -376,7 +376,7 @@
     "compressedSize" : 23421,
     "uncompressedSize" : 89409,
     "compressionMethod" : "Deflated",
-    "checkSum" : "d8f1175d81204f68f9a12eeeeaa65eeff0ae6434d3e5c91fdd602938f296bd5",
+    "checkSum" : "4a76e8882143e89e4c4bd421210a0f4a06761f7d957fded14347613b7a2caab",
     "isSpineItem" : true,
     "spineIndex" : 1,
     "isLinear" : true,
@@ -390,7 +390,7 @@
     "renditionLayout" : "reflowable",
     "renditionOrientation" : "auto",
     "renditionSpread" : "auto",
-    "referencedItems" : [ "OPS/image11.jpg", "OPS/image12.jpg", "OPS/image3.jpg", "OPS/image1.jpg", "OPS/image13.jpg", "OPS/image2.jpg", "OPS/image5.jpg", "OPS/image4.jpg", "OPS/image14.jpg" ]
+    "referencedItems" : [ "OPS/image1.jpg", "OPS/image11.jpg", "OPS/image12.jpg", "OPS/image13.jpg", "OPS/image14.jpg", "OPS/image2.jpg", "OPS/image3.jpg", "OPS/image4.jpg", "OPS/image5.jpg" ]
   } ],
   "messages" : [ {
     "ID" : "HTM-010",

--- a/src/test/resources/com/adobe/epubcheck/test/command_line/failonwarnings_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/command_line/failonwarnings_expected_results.json
@@ -1,11 +1,11 @@
 {
   "customMessageFileName" : null,
   "checker" : {
-    "path" : "./com/adobe/epubcheck/test/command_line/failonwarnings.epub",
+    "path" : "./target/test-classes/com/adobe/epubcheck/test/command_line/failonwarnings.epub",
     "filename" : "failonwarnings.epub",
-    "checkerVersion" : "4.0.0-alpha11-SNAPSHOT",
-    "checkDate" : "09-05-2014 03:32:18",
-    "elapsedTime" : 3687,
+    "checkerVersion" : "4.0.0-alpha12-SNAPSHOT",
+    "checkDate" : "03-25-2015 10:06:20",
+    "elapsedTime" : 62,
     "nFatal" : 0,
     "nError" : 0,
     "nWarning" : 1,
@@ -236,7 +236,7 @@
     "renditionLayout" : null,
     "renditionOrientation" : null,
     "renditionSpread" : null,
-    "referencedItems" : [ "OPS/style_tag_css.xhtml", "OPS/inline_css.xhtml", "OPS/external_css.xhtml" ]
+    "referencedItems" : [ "OPS/external_css.xhtml", "OPS/inline_css.xhtml", "OPS/style_tag_css.xhtml" ]
   } ],
   "messages" : [ {
     "ID" : "ACC-007",

--- a/src/test/resources/com/adobe/epubcheck/test/command_line/jsonfile_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/command_line/jsonfile_expected_results.json
@@ -1,11 +1,11 @@
 {
   "customMessageFileName" : null,
   "checker" : {
-    "path" : "./com/adobe/epubcheck/test/command_line/jsonfile.epub",
+    "path" : "./target/test-classes/com/adobe/epubcheck/test/command_line/jsonfile.epub",
     "filename" : "jsonfile.epub",
-    "checkerVersion" : "4.0.0-alpha11-SNAPSHOT",
-    "checkDate" : "09-05-2014 03:27:51",
-    "elapsedTime" : 130,
+    "checkerVersion" : "4.0.0-alpha12-SNAPSHOT",
+    "checkDate" : "03-25-2015 10:06:20",
+    "elapsedTime" : 58,
     "nFatal" : 0,
     "nError" : 0,
     "nWarning" : 0,
@@ -236,7 +236,7 @@
     "renditionLayout" : null,
     "renditionOrientation" : null,
     "renditionSpread" : null,
-    "referencedItems" : [ "OPS/style_tag_css.xhtml", "OPS/inline_css.xhtml", "OPS/external_css.xhtml" ]
+    "referencedItems" : [ "OPS/external_css.xhtml", "OPS/inline_css.xhtml", "OPS/style_tag_css.xhtml" ]
   } ],
   "messages" : [ {
     "ID" : "ACC-007",

--- a/src/test/resources/com/adobe/epubcheck/test/command_line/passonwarnings_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/command_line/passonwarnings_expected_results.json
@@ -1,11 +1,11 @@
 {
   "customMessageFileName" : null,
   "checker" : {
-    "path" : "./com/adobe/epubcheck/test/command_line/passonwarnings.epub",
+    "path" : "./target/test-classes/com/adobe/epubcheck/test/command_line/passonwarnings.epub",
     "filename" : "passonwarnings.epub",
-    "checkerVersion" : "4.0.0-alpha11-SNAPSHOT",
-    "checkDate" : "09-05-2014 03:15:54",
-    "elapsedTime" : 134,
+    "checkerVersion" : "4.0.0-alpha12-SNAPSHOT",
+    "checkDate" : "03-25-2015 10:06:20",
+    "elapsedTime" : 68,
     "nFatal" : 0,
     "nError" : 0,
     "nWarning" : 0,
@@ -236,7 +236,7 @@
     "renditionLayout" : null,
     "renditionOrientation" : null,
     "renditionSpread" : null,
-    "referencedItems" : [ "OPS/style_tag_css.xhtml", "OPS/inline_css.xhtml", "OPS/external_css.xhtml" ]
+    "referencedItems" : [ "OPS/external_css.xhtml", "OPS/inline_css.xhtml", "OPS/style_tag_css.xhtml" ]
   } ],
   "messages" : [ {
     "ID" : "ACC-007",

--- a/src/test/resources/com/adobe/epubcheck/test/command_line/xmlfile_expected_results.xmp
+++ b/src/test/resources/com/adobe/epubcheck/test/command_line/xmlfile_expected_results.xmp
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="Adobe XMP Core 5.1.0-jc003">
  <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-  <rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xmp="http://ns.adobe.com/xap/1.0/" xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/" xmlns:stFnt="http://ns.adobe.com/xap/1.0/sType/Font#" xmlns:extended-properties="http://schemas.openxmlformats.org/officeDocument/2006/extended-properties/" xmlns:premis="http://www.loc.gov/premis/rdf/v1#" dc:format="application/epub+zip;version=3.0" xmp:CreateDate="2014-10-26T22:46:14Z" extended-properties:Characters="648" dc:identifier="000000000000000000" dc:language="en">
+  <rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xmp="http://ns.adobe.com/xap/1.0/" xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/" xmlns:stFnt="http://ns.adobe.com/xap/1.0/sType/Font#" xmlns:extended-properties="http://schemas.openxmlformats.org/officeDocument/2006/extended-properties/" xmlns:premis="http://www.loc.gov/premis/rdf/v1#" dc:format="application/epub+zip;version=3.0" xmp:CreateDate="2015-03-25T17:44:28Z" extended-properties:Characters="648" dc:identifier="000000000000000000" dc:language="en">
    <dc:title>
     <rdf:Alt>
      <rdf:li xml:lang="x-default">Transform Sample Book</rdf:li>
     </rdf:Alt>
    </dc:title>
    <premis:hasEvent rdf:parseType="Resource">
-    <premis:hasEventDateTime rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2014-10-26T22:55:08+01:00</premis:hasEventDateTime>
+    <premis:hasEventDateTime rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-03-25T17:44:33+01:00</premis:hasEventDateTime>
     <premis:hasEventType rdf:resource="http://id.loc.gov/vocabulary/preservation/eventType/val" />
     <premis:hasEventDetail>Well-formed</premis:hasEventDetail>
     <premis:hasEventOutcomeInformation>
@@ -53,10 +53,10 @@
        <premis:hasEventOutcome>ACC-013, HINT, Content file contains at least one inline style declaration.</premis:hasEventOutcome>
        <premis:hasEventOutcomeDetail>
         <rdf:Seq>
-         <rdf:li premis:hasEventOutcomeDetailNote="OPS/inline_css.xhtml (14-116)" />
          <rdf:li premis:hasEventOutcomeDetailNote="OPS/inline_css.xhtml (10-119)" />
-         <rdf:li premis:hasEventOutcomeDetailNote="OPS/inline_css.xhtml (15-114)" />
          <rdf:li premis:hasEventOutcomeDetailNote="OPS/inline_css.xhtml (11-115)" />
+         <rdf:li premis:hasEventOutcomeDetailNote="OPS/inline_css.xhtml (14-116)" />
+         <rdf:li premis:hasEventOutcomeDetailNote="OPS/inline_css.xhtml (15-114)" />
         </rdf:Seq>
        </premis:hasEventOutcomeDetail>
       </rdf:li>
@@ -74,7 +74,7 @@
     </premis:hasEventOutcomeInformation>
     <premis:hasEventRelatedAgent rdf:parseType="Resource">
      <premis:hasAgentType rdf:resource="http://id.loc.gov/vocabulary/preservation/agentType/sof" />
-     <premis:hasAgentName>epubcheck 4.0.0</premis:hasAgentName>
+     <premis:hasAgentName>epubcheck 4.0.0-alpha12-SNAPSHOT</premis:hasAgentName>
     </premis:hasEventRelatedAgent>
    </premis:hasEvent>
    <premis:hasSignificantProperties>

--- a/src/test/resources/com/adobe/epubcheck/test/css/alternate_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/css/alternate_expected_results.json
@@ -1,11 +1,11 @@
 {
   "customMessageFileName" : null,
   "checker" : {
-    "path" : "./com/adobe/epubcheck/test/css/alternate.epub",
+    "path" : "./target/test-classes/com/adobe/epubcheck/test/css/alternate.epub",
     "filename" : "alternate.epub",
-    "checkerVersion" : "4.0.0-alpha11-SNAPSHOT",
-    "checkDate" : "09-05-2014 03:17:17",
-    "elapsedTime" : 384,
+    "checkerVersion" : "4.0.0-alpha12-SNAPSHOT",
+    "checkDate" : "03-25-2015 10:06:37",
+    "elapsedTime" : 57,
     "nFatal" : 0,
     "nError" : 1,
     "nWarning" : 0,
@@ -148,7 +148,7 @@
     "renditionLayout" : "reflowable",
     "renditionOrientation" : "auto",
     "renditionSpread" : "auto",
-    "referencedItems" : [ "OPS/styles/chocolate.css", "OPS/styles/style.css", "OPS/styles/midnight.css" ]
+    "referencedItems" : [ "OPS/styles/chocolate.css", "OPS/styles/midnight.css", "OPS/styles/style.css" ]
   }, {
     "id" : "page02",
     "fileName" : "OPS/page02.xhtml",

--- a/src/test/resources/com/adobe/epubcheck/test/css/columns_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/css/columns_expected_results.json
@@ -1,11 +1,11 @@
 {
   "customMessageFileName" : null,
   "checker" : {
-    "path" : "./com/adobe/epubcheck/test/css/columns.epub",
+    "path" : "./target/test-classes/com/adobe/epubcheck/test/css/columns.epub",
     "filename" : "columns.epub",
-    "checkerVersion" : "4.0.0-alpha11-SNAPSHOT",
-    "checkDate" : "09-05-2014 03:17:14",
-    "elapsedTime" : 345,
+    "checkerVersion" : "4.0.0-alpha12-SNAPSHOT",
+    "checkDate" : "03-25-2015 10:06:37",
+    "elapsedTime" : 44,
     "nFatal" : 0,
     "nError" : 0,
     "nWarning" : 0,
@@ -236,7 +236,7 @@
     "renditionLayout" : null,
     "renditionOrientation" : null,
     "renditionSpread" : null,
-    "referencedItems" : [ "OPS/style_tag_css.xhtml", "OPS/inline_css.xhtml", "OPS/external_css.xhtml" ]
+    "referencedItems" : [ "OPS/external_css.xhtml", "OPS/inline_css.xhtml", "OPS/style_tag_css.xhtml" ]
   } ],
   "messages" : [ {
     "ID" : "ACC-007",

--- a/src/test/resources/com/adobe/epubcheck/test/css/discouraged_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/css/discouraged_expected_results.json
@@ -1,11 +1,11 @@
 {
   "customMessageFileName" : null,
   "checker" : {
-    "path" : "./com/adobe/epubcheck/test/css/discouraged.epub",
+    "path" : "./target/test-classes/com/adobe/epubcheck/test/css/discouraged.epub",
     "filename" : "discouraged.epub",
-    "checkerVersion" : "4.0.0-alpha11-SNAPSHOT",
-    "checkDate" : "09-05-2014 03:17:16",
-    "elapsedTime" : 270,
+    "checkerVersion" : "4.0.0-alpha12-SNAPSHOT",
+    "checkDate" : "03-25-2015 10:06:37",
+    "elapsedTime" : 46,
     "nFatal" : 0,
     "nError" : 2,
     "nWarning" : 2,
@@ -148,7 +148,7 @@
     "renditionLayout" : "reflowable",
     "renditionOrientation" : "auto",
     "renditionSpread" : "auto",
-    "referencedItems" : [ "OPS/style.css", "OPS/cssStyles.css" ]
+    "referencedItems" : [ "OPS/cssStyles.css", "OPS/style.css" ]
   }, {
     "id" : "page02",
     "fileName" : "OPS/style_tag_css.xhtml",
@@ -280,7 +280,7 @@
     "renditionLayout" : null,
     "renditionOrientation" : null,
     "renditionSpread" : null,
-    "referencedItems" : [ "OPS/style_tag_css.xhtml", "OPS/inline_css.xhtml", "OPS/external_css.xhtml" ]
+    "referencedItems" : [ "OPS/external_css.xhtml", "OPS/inline_css.xhtml", "OPS/style_tag_css.xhtml" ]
   } ],
   "messages" : [ {
     "ID" : "ACC-007",

--- a/src/test/resources/com/adobe/epubcheck/test/css/font-face_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/css/font-face_expected_results.json
@@ -1,11 +1,11 @@
 {
   "customMessageFileName" : null,
   "checker" : {
-    "path" : "./com/adobe/epubcheck/test/css/font-face.epub",
+    "path" : "./target/test-classes/com/adobe/epubcheck/test/css/font-face.epub",
     "filename" : "font-face.epub",
-    "checkerVersion" : "4.0.0-alpha11-SNAPSHOT",
-    "checkDate" : "09-05-2014 03:17:15",
-    "elapsedTime" : 306,
+    "checkerVersion" : "4.0.0-alpha12-SNAPSHOT",
+    "checkDate" : "03-25-2015 10:06:37",
+    "elapsedTime" : 54,
     "nFatal" : 0,
     "nError" : 4,
     "nWarning" : 2,
@@ -214,7 +214,7 @@
     "renditionLayout" : "reflowable",
     "renditionOrientation" : "auto",
     "renditionSpread" : "auto",
-    "referencedItems" : [ "http://fonts.googleapis.com/css?family=Chela+One", "OPS/styles/style.css" ]
+    "referencedItems" : [ "OPS/styles/style.css", "http://fonts.googleapis.com/css?family=Chela+One" ]
   }, {
     "id" : "page02",
     "fileName" : "OPS/style_tag_css.xhtml",
@@ -280,7 +280,7 @@
     "renditionLayout" : null,
     "renditionOrientation" : null,
     "renditionSpread" : null,
-    "referencedItems" : [ "OPS/fonts/badaboom.woff", "OPS/fonts/Fummel.otf", "OPS/styles/fonts/bloody.woff", "OPS/fonts/bloody.woff", "http://developer.mozilla.org/@api/deki/files/2934/=VeraSeBd.ttf", "OPS/fonts/brankovic.ttf" ]
+    "referencedItems" : [ "OPS/fonts/Fummel.otf", "OPS/fonts/badaboom.woff", "OPS/fonts/bloody.woff", "OPS/fonts/brankovic.ttf", "OPS/styles/fonts/bloody.woff", "http://developer.mozilla.org/@api/deki/files/2934/=VeraSeBd.ttf" ]
   }, {
     "id" : "toc",
     "fileName" : "OPS/toc.xhtml",
@@ -302,7 +302,7 @@
     "renditionLayout" : null,
     "renditionOrientation" : null,
     "renditionSpread" : null,
-    "referencedItems" : [ "OPS/style_tag_css.xhtml", "OPS/inline_css.xhtml", "OPS/external_css.xhtml" ]
+    "referencedItems" : [ "OPS/external_css.xhtml", "OPS/inline_css.xhtml", "OPS/style_tag_css.xhtml" ]
   } ],
   "messages" : [ {
     "ID" : "ACC-007",

--- a/src/test/resources/com/adobe/epubcheck/test/css/font-face_expected_results.xmp
+++ b/src/test/resources/com/adobe/epubcheck/test/css/font-face_expected_results.xmp
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="Adobe XMP Core 5.1.0-jc003">
  <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-  <rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xmp="http://ns.adobe.com/xap/1.0/" xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/" xmlns:stFnt="http://ns.adobe.com/xap/1.0/sType/Font#" xmlns:extended-properties="http://schemas.openxmlformats.org/officeDocument/2006/extended-properties/" xmlns:premis="http://www.loc.gov/premis/rdf/v1#" dc:format="application/epub+zip;version=3.0" xmp:CreateDate="2014-10-26T22:46:16Z" extended-properties:Characters="2205" dc:identifier="000000000000000000" dc:language="en">
+  <rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xmp="http://ns.adobe.com/xap/1.0/" xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/" xmlns:stFnt="http://ns.adobe.com/xap/1.0/sType/Font#" xmlns:extended-properties="http://schemas.openxmlformats.org/officeDocument/2006/extended-properties/" xmlns:premis="http://www.loc.gov/premis/rdf/v1#" dc:format="application/epub+zip;version=3.0" xmp:CreateDate="2015-03-25T10:04:00Z" extended-properties:Characters="2205" dc:identifier="000000000000000000" dc:language="en">
    <dc:title>
     <rdf:Alt>
      <rdf:li xml:lang="x-default">Font Face Sample Book</rdf:li>
@@ -20,7 +20,7 @@
     </rdf:Bag>
    </xmpTPg:Fonts>
    <premis:hasEvent rdf:parseType="Resource">
-    <premis:hasEventDateTime rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2014-11-06T21:13:17+01:00</premis:hasEventDateTime>
+    <premis:hasEventDateTime rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-03-25T10:06:37+01:00</premis:hasEventDateTime>
     <premis:hasEventType rdf:resource="http://id.loc.gov/vocabulary/preservation/eventType/val" />
     <premis:hasEventDetail>Not well-formed</premis:hasEventDetail>
     <premis:hasEventOutcomeInformation>
@@ -214,7 +214,7 @@
     </premis:hasEventOutcomeInformation>
     <premis:hasEventRelatedAgent rdf:parseType="Resource">
      <premis:hasAgentType rdf:resource="http://id.loc.gov/vocabulary/preservation/agentType/sof" />
-     <premis:hasAgentName>epubcheck 4.0.0</premis:hasAgentName>
+     <premis:hasAgentName>epubcheck 4.0.0-alpha12-SNAPSHOT</premis:hasAgentName>
     </premis:hasEventRelatedAgent>
    </premis:hasEvent>
    <premis:hasSignificantProperties>

--- a/src/test/resources/com/adobe/epubcheck/test/css/font_encryption_idpf_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/css/font_encryption_idpf_expected_results.json
@@ -1,11 +1,11 @@
 {
   "customMessageFileName" : null,
   "checker" : {
-    "path" : "./com/adobe/epubcheck/test/css/font_encryption_idpf.epub",
+    "path" : "./target/test-classes/com/adobe/epubcheck/test/css/font_encryption_idpf.epub",
     "filename" : "font_encryption_idpf.epub",
-    "checkerVersion" : "4.0.0-alpha11-SNAPSHOT",
-    "checkDate" : "09-05-2014 03:17:17",
-    "elapsedTime" : 704,
+    "checkerVersion" : "4.0.0-alpha12-SNAPSHOT",
+    "checkDate" : "03-25-2015 10:06:38",
+    "elapsedTime" : 400,
     "nFatal" : 0,
     "nError" : 0,
     "nWarning" : 0,
@@ -434,7 +434,7 @@
     "renditionLayout" : null,
     "renditionOrientation" : null,
     "renditionSpread" : null,
-    "referencedItems" : [ "Css-fontface/fonts/OldStandard-Italic.otf", "Css-fontface/fonts/OldStandard-Bold.obf.woff", "Css-fontface/fonts/OldStandard-Regular.obf.woff", "Css-fontface/fonts/OldStandard-Italic.obf.otf", "Css-fontface/fonts/OldStandard-Regular.obf.otf", "Css-fontface/fonts/OldStandard-Bold.otf", "Css-fontface/fonts/OldStandard-Regular.otf", "Css-fontface/fonts/OldStandard-Italic.obf.woff", "Css-fontface/fonts/OldStandard-Italic.woff", "Css-fontface/fonts/OldStandard-Bold.obf.otf", "Css-fontface/fonts/OldStandard-Bold.woff", "Css-fontface/fonts/OldStandard-Regular.woff" ]
+    "referencedItems" : [ "Css-fontface/fonts/OldStandard-Bold.obf.otf", "Css-fontface/fonts/OldStandard-Bold.obf.woff", "Css-fontface/fonts/OldStandard-Bold.otf", "Css-fontface/fonts/OldStandard-Bold.woff", "Css-fontface/fonts/OldStandard-Italic.obf.otf", "Css-fontface/fonts/OldStandard-Italic.obf.woff", "Css-fontface/fonts/OldStandard-Italic.otf", "Css-fontface/fonts/OldStandard-Italic.woff", "Css-fontface/fonts/OldStandard-Regular.obf.otf", "Css-fontface/fonts/OldStandard-Regular.obf.woff", "Css-fontface/fonts/OldStandard-Regular.otf", "Css-fontface/fonts/OldStandard-Regular.woff" ]
   }, {
     "id" : "pg1",
     "fileName" : "Css-fontface/pages/pg1.xhtml",
@@ -522,7 +522,7 @@
     "renditionLayout" : "reflowable",
     "renditionOrientation" : "auto",
     "renditionSpread" : "auto",
-    "referencedItems" : [ "Css-fontface/pages/pg2.xhtml", "Css-fontface/pages/pg1.xhtml", "Css-fontface/pages/pg3.xhtml" ]
+    "referencedItems" : [ "Css-fontface/pages/pg1.xhtml", "Css-fontface/pages/pg2.xhtml", "Css-fontface/pages/pg3.xhtml" ]
   } ],
   "messages" : [ {
     "ID" : "ACC-007",

--- a/src/test/resources/com/adobe/epubcheck/test/css/font_encryption_idpf_expected_results.xmp
+++ b/src/test/resources/com/adobe/epubcheck/test/css/font_encryption_idpf_expected_results.xmp
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="Adobe XMP Core 5.1.0-jc003">
  <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-  <rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xmp="http://ns.adobe.com/xap/1.0/" xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/" xmlns:stFnt="http://ns.adobe.com/xap/1.0/sType/Font#" xmlns:extended-properties="http://schemas.openxmlformats.org/officeDocument/2006/extended-properties/" xmlns:premis="http://www.loc.gov/premis/rdf/v1#" dc:format="application/epub+zip;version=3.0" xmp:CreateDate="2014-10-26T22:46:16Z" extended-properties:Characters="2904" dc:publisher="Epub3 Team" dc:identifier="epub3.test" dc:language="en-US">
+  <rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xmp="http://ns.adobe.com/xap/1.0/" xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/" xmlns:stFnt="http://ns.adobe.com/xap/1.0/sType/Font#" xmlns:extended-properties="http://schemas.openxmlformats.org/officeDocument/2006/extended-properties/" xmlns:premis="http://www.loc.gov/premis/rdf/v1#" dc:format="application/epub+zip;version=3.0" xmp:CreateDate="2015-03-25T17:55:06Z" extended-properties:Characters="2904" dc:publisher="Epub3 Team" dc:identifier="epub3.test" dc:language="en-US">
    <dc:creator>
     <rdf:Seq>
      <rdf:li>David</rdf:li>
@@ -29,7 +29,7 @@
     </rdf:Bag>
    </xmpTPg:Fonts>
    <premis:hasEvent rdf:parseType="Resource">
-    <premis:hasEventDateTime rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2014-11-06T21:19:08+01:00</premis:hasEventDateTime>
+    <premis:hasEventDateTime rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-03-25T17:55:13+01:00</premis:hasEventDateTime>
     <premis:hasEventType rdf:resource="http://id.loc.gov/vocabulary/preservation/eventType/val" />
     <premis:hasEventDetail>Well-formed</premis:hasEventDetail>
     <premis:hasEventOutcomeInformation>
@@ -54,21 +54,21 @@
        <premis:hasEventOutcome>ACC-013, HINT, Content file contains at least one inline style declaration.</premis:hasEventOutcome>
        <premis:hasEventOutcomeDetail>
         <rdf:Seq>
+         <rdf:li premis:hasEventOutcomeDetailNote="Css-fontface/pages/pg1.xhtml (11-51)" />
+         <rdf:li premis:hasEventOutcomeDetailNote="Css-fontface/pages/pg1.xhtml (15-52)" />
+         <rdf:li premis:hasEventOutcomeDetailNote="Css-fontface/pages/pg1.xhtml (19-55)" />
          <rdf:li premis:hasEventOutcomeDetailNote="Css-fontface/pages/pg1.xhtml (23-56)" />
          <rdf:li premis:hasEventOutcomeDetailNote="Css-fontface/pages/pg1.xhtml (33-44)" />
-         <rdf:li premis:hasEventOutcomeDetailNote="Css-fontface/pages/pg1.xhtml (11-51)" />
-         <rdf:li premis:hasEventOutcomeDetailNote="Css-fontface/pages/pg1.xhtml (19-55)" />
-         <rdf:li premis:hasEventOutcomeDetailNote="Css-fontface/pages/pg1.xhtml (15-52)" />
          <rdf:li premis:hasEventOutcomeDetailNote="Css-fontface/pages/pg2.xhtml (11-68)" />
-         <rdf:li premis:hasEventOutcomeDetailNote="Css-fontface/pages/pg2.xhtml (35-61)" />
          <rdf:li premis:hasEventOutcomeDetailNote="Css-fontface/pages/pg2.xhtml (15-69)" />
          <rdf:li premis:hasEventOutcomeDetailNote="Css-fontface/pages/pg2.xhtml (19-72)" />
          <rdf:li premis:hasEventOutcomeDetailNote="Css-fontface/pages/pg2.xhtml (23-73)" />
+         <rdf:li premis:hasEventOutcomeDetailNote="Css-fontface/pages/pg2.xhtml (35-61)" />
          <rdf:li premis:hasEventOutcomeDetailNote="Css-fontface/pages/pg3.xhtml (11-69)" />
-         <rdf:li premis:hasEventOutcomeDetailNote="Css-fontface/pages/pg3.xhtml (35-62)" />
          <rdf:li premis:hasEventOutcomeDetailNote="Css-fontface/pages/pg3.xhtml (15-70)" />
-         <rdf:li premis:hasEventOutcomeDetailNote="Css-fontface/pages/pg3.xhtml (23-74)" />
          <rdf:li premis:hasEventOutcomeDetailNote="Css-fontface/pages/pg3.xhtml (19-73)" />
+         <rdf:li premis:hasEventOutcomeDetailNote="Css-fontface/pages/pg3.xhtml (23-74)" />
+         <rdf:li premis:hasEventOutcomeDetailNote="Css-fontface/pages/pg3.xhtml (35-62)" />
         </rdf:Seq>
        </premis:hasEventOutcomeDetail>
       </rdf:li>
@@ -120,7 +120,7 @@
     </premis:hasEventOutcomeInformation>
     <premis:hasEventRelatedAgent rdf:parseType="Resource">
      <premis:hasAgentType rdf:resource="http://id.loc.gov/vocabulary/preservation/agentType/sof" />
-     <premis:hasAgentName>epubcheck 4.0.0</premis:hasAgentName>
+     <premis:hasAgentName>epubcheck 4.0.0-alpha12-SNAPSHOT</premis:hasAgentName>
     </premis:hasEventRelatedAgent>
    </premis:hasEvent>
    <premis:hasSignificantProperties>

--- a/src/test/resources/com/adobe/epubcheck/test/css/keyframe_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/css/keyframe_expected_results.json
@@ -1,11 +1,11 @@
 {
   "customMessageFileName" : null,
   "checker" : {
-    "path" : "./com/adobe/epubcheck/test/css/keyframe.epub",
+    "path" : "./target/test-classes/com/adobe/epubcheck/test/css/keyframe.epub",
     "filename" : "keyframe.epub",
-    "checkerVersion" : "4.0.0-alpha11-SNAPSHOT",
-    "checkDate" : "09-05-2014 03:17:15",
-    "elapsedTime" : 310,
+    "checkerVersion" : "4.0.0-alpha12-SNAPSHOT",
+    "checkDate" : "03-25-2015 10:06:37",
+    "elapsedTime" : 46,
     "nFatal" : 0,
     "nError" : 0,
     "nWarning" : 0,
@@ -236,7 +236,7 @@
     "renditionLayout" : null,
     "renditionOrientation" : null,
     "renditionSpread" : null,
-    "referencedItems" : [ "OPS/style_tag_css.xhtml", "OPS/inline_css.xhtml", "OPS/external_css.xhtml" ]
+    "referencedItems" : [ "OPS/external_css.xhtml", "OPS/inline_css.xhtml", "OPS/style_tag_css.xhtml" ]
   } ],
   "messages" : [ {
     "ID" : "ACC-007",

--- a/src/test/resources/com/adobe/epubcheck/test/css/multiple_epub3_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/css/multiple_epub3_expected_results.json
@@ -1,11 +1,11 @@
 {
   "customMessageFileName" : null,
   "checker" : {
-    "path" : "./com/adobe/epubcheck/test/css/multiple_epub3.epub",
+    "path" : "./target/test-classes/com/adobe/epubcheck/test/css/multiple_epub3.epub",
     "filename" : "multiple_epub3.epub",
-    "checkerVersion" : "4.0.0-alpha11-SNAPSHOT",
-    "checkDate" : "09-05-2014 03:17:16",
-    "elapsedTime" : 252,
+    "checkerVersion" : "4.0.0-alpha12-SNAPSHOT",
+    "checkDate" : "03-25-2015 10:06:37",
+    "elapsedTime" : 42,
     "nFatal" : 0,
     "nError" : 1,
     "nWarning" : 0,
@@ -148,7 +148,7 @@
     "renditionLayout" : "reflowable",
     "renditionOrientation" : "auto",
     "renditionSpread" : "auto",
-    "referencedItems" : [ "OPS/style.css", "OPS/styleUTF32.css", "OPS/style2.css" ]
+    "referencedItems" : [ "OPS/style.css", "OPS/style2.css", "OPS/styleUTF32.css" ]
   }, {
     "id" : "page02",
     "fileName" : "OPS/style_tag_css.xhtml",
@@ -280,7 +280,7 @@
     "renditionLayout" : null,
     "renditionOrientation" : null,
     "renditionSpread" : null,
-    "referencedItems" : [ "OPS/style_tag_css.xhtml", "OPS/inline_css.xhtml", "OPS/external_css.xhtml" ]
+    "referencedItems" : [ "OPS/external_css.xhtml", "OPS/inline_css.xhtml", "OPS/style_tag_css.xhtml" ]
   } ],
   "messages" : [ {
     "ID" : "ACC-007",

--- a/src/test/resources/com/adobe/epubcheck/test/css/transform_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/css/transform_expected_results.json
@@ -1,11 +1,11 @@
 {
   "customMessageFileName" : null,
   "checker" : {
-    "path" : "./com/adobe/epubcheck/test/css/transform.epub",
+    "path" : "./target/test-classes/com/adobe/epubcheck/test/css/transform.epub",
     "filename" : "transform.epub",
-    "checkerVersion" : "4.0.0-alpha11-SNAPSHOT",
-    "checkDate" : "09-05-2014 03:17:10",
-    "elapsedTime" : 3762,
+    "checkerVersion" : "4.0.0-alpha12-SNAPSHOT",
+    "checkDate" : "03-25-2015 10:06:37",
+    "elapsedTime" : 44,
     "nFatal" : 0,
     "nError" : 0,
     "nWarning" : 0,
@@ -236,7 +236,7 @@
     "renditionLayout" : null,
     "renditionOrientation" : null,
     "renditionSpread" : null,
-    "referencedItems" : [ "OPS/style_tag_css.xhtml", "OPS/inline_css.xhtml", "OPS/external_css.xhtml" ]
+    "referencedItems" : [ "OPS/external_css.xhtml", "OPS/inline_css.xhtml", "OPS/style_tag_css.xhtml" ]
   } ],
   "messages" : [ {
     "ID" : "ACC-007",

--- a/src/test/resources/com/adobe/epubcheck/test/css/transition_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/css/transition_expected_results.json
@@ -1,11 +1,11 @@
 {
   "customMessageFileName" : null,
   "checker" : {
-    "path" : "./com/adobe/epubcheck/test/css/transition.epub",
+    "path" : "./target/test-classes/com/adobe/epubcheck/test/css/transition.epub",
     "filename" : "transition.epub",
-    "checkerVersion" : "4.0.0-alpha11-SNAPSHOT",
-    "checkDate" : "09-05-2014 03:17:15",
-    "elapsedTime" : 332,
+    "checkerVersion" : "4.0.0-alpha12-SNAPSHOT",
+    "checkDate" : "03-25-2015 10:06:37",
+    "elapsedTime" : 43,
     "nFatal" : 0,
     "nError" : 0,
     "nWarning" : 0,
@@ -236,7 +236,7 @@
     "renditionLayout" : null,
     "renditionOrientation" : null,
     "renditionSpread" : null,
-    "referencedItems" : [ "OPS/style_tag_css.xhtml", "OPS/inline_css.xhtml", "OPS/external_css.xhtml" ]
+    "referencedItems" : [ "OPS/external_css.xhtml", "OPS/inline_css.xhtml", "OPS/style_tag_css.xhtml" ]
   } ],
   "messages" : [ {
     "ID" : "ACC-007",

--- a/src/test/resources/com/adobe/epubcheck/test/opf/Media-type_handler_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/opf/Media-type_handler_expected_results.json
@@ -1,11 +1,11 @@
 {
   "customMessageFileName" : null,
   "checker" : {
-    "path" : "./com/adobe/epubcheck/test/opf/Media-type_handler.epub",
+    "path" : "./target/test-classes/com/adobe/epubcheck/test/opf/Media-type_handler.epub",
     "filename" : "Media-type_handler.epub",
-    "checkerVersion" : "4.0.0-alpha11-SNAPSHOT",
-    "checkDate" : "09-05-2014 03:15:48",
-    "elapsedTime" : 515,
+    "checkerVersion" : "4.0.0-alpha12-SNAPSHOT",
+    "checkDate" : "03-25-2015 10:06:15",
+    "elapsedTime" : 313,
     "nFatal" : 0,
     "nError" : 5,
     "nWarning" : 0,
@@ -192,7 +192,7 @@
     "renditionLayout" : "reflowable",
     "renditionOrientation" : "auto",
     "renditionSpread" : "auto",
-    "referencedItems" : [ "OPS/images/image4.jpg", "OPS/images/image1.jpg", "OPS/settings.xml", "OPS/slideshow.xml", "OPS/images/image2.jpg", "OPS/images/image3.jpg" ]
+    "referencedItems" : [ "OPS/images/image1.jpg", "OPS/images/image2.jpg", "OPS/images/image3.jpg", "OPS/images/image4.jpg", "OPS/settings.xml", "OPS/slideshow.xml" ]
   }, {
     "id" : "pict1",
     "fileName" : "OPS/images/image1.jpg",

--- a/src/test/resources/com/adobe/epubcheck/test/opf/viewport2_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/opf/viewport2_expected_results.json
@@ -1,11 +1,11 @@
 {
   "customMessageFileName" : null,
   "checker" : {
-    "path" : "./com/adobe/epubcheck/test/opf/viewport2.epub",
+    "path" : "./target/test-classes/com/adobe/epubcheck/test/opf/viewport2.epub",
     "filename" : "viewport2.epub",
-    "checkerVersion" : "4.0.0-alpha11-SNAPSHOT",
-    "checkDate" : "09-05-2014 03:15:43",
-    "elapsedTime" : 244,
+    "checkerVersion" : "4.0.0-alpha12-SNAPSHOT",
+    "checkDate" : "03-25-2015 10:19:17",
+    "elapsedTime" : 90,
     "nFatal" : 0,
     "nError" : 2,
     "nWarning" : 0,
@@ -126,7 +126,7 @@
     "renditionLayout" : null,
     "renditionOrientation" : null,
     "renditionSpread" : null,
-    "referencedItems" : [ "OPS/toc.xhtml", "OPS/page003.xhtml", "OPS/page001.xhtml", "OPS/page004.xhtml", "OPS/page002.xhtml" ]
+    "referencedItems" : [ "OPS/page001.xhtml", "OPS/page002.xhtml", "OPS/page003.xhtml", "OPS/page004.xhtml", "OPS/toc.xhtml" ]
   }, {
     "id" : "page001",
     "fileName" : "OPS/page001.xhtml",
@@ -236,7 +236,7 @@
     "renditionLayout" : "reflowable",
     "renditionOrientation" : "auto",
     "renditionSpread" : "auto",
-    "referencedItems" : [ "OPS/page003.xhtml", "OPS/page001.xhtml", "OPS/page004.xhtml", "OPS/page002.xhtml" ]
+    "referencedItems" : [ "OPS/page001.xhtml", "OPS/page002.xhtml", "OPS/page003.xhtml", "OPS/page004.xhtml" ]
   } ],
   "messages" : [ {
     "ID" : "ACC-007",

--- a/src/test/resources/com/adobe/epubcheck/test/opf/viewport_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/opf/viewport_expected_results.json
@@ -1,11 +1,11 @@
 {
   "customMessageFileName" : null,
   "checker" : {
-    "path" : "./com/adobe/epubcheck/test/opf/viewport.epub",
+    "path" : "./target/test-classes/com/adobe/epubcheck/test/opf/viewport.epub",
     "filename" : "viewport.epub",
-    "checkerVersion" : "4.0.0-alpha11-SNAPSHOT",
-    "checkDate" : "09-05-2014 03:15:43",
-    "elapsedTime" : 295,
+    "checkerVersion" : "4.0.0-alpha12-SNAPSHOT",
+    "checkDate" : "03-25-2015 00:26:05",
+    "elapsedTime" : 2259,
     "nFatal" : 0,
     "nError" : 3,
     "nWarning" : 0,
@@ -126,7 +126,7 @@
     "renditionLayout" : null,
     "renditionOrientation" : null,
     "renditionSpread" : null,
-    "referencedItems" : [ "OPS/page008.svg", "OPS/toc.xhtml", "OPS/page003.xhtml", "OPS/page005.svg", "OPS/page007.svg", "OPS/page001.xhtml", "OPS/page004.xhtml", "OPS/page002.xhtml", "OPS/page006.svg" ]
+    "referencedItems" : [ "OPS/page001.xhtml", "OPS/page002.xhtml", "OPS/page003.xhtml", "OPS/page004.xhtml", "OPS/page005.svg", "OPS/page006.svg", "OPS/page007.svg", "OPS/page008.svg", "OPS/toc.xhtml" ]
   }, {
     "id" : "page001",
     "fileName" : "OPS/page001.xhtml",
@@ -346,7 +346,7 @@
     "renditionLayout" : "pre-paginated",
     "renditionOrientation" : "auto",
     "renditionSpread" : "auto",
-    "referencedItems" : [ "OPS/page008.svg", "OPS/page003.xhtml", "OPS/page005.svg", "OPS/page007.svg", "OPS/page001.xhtml", "OPS/page005.xhtml", "OPS/page004.xhtml", "OPS/page002.xhtml", "OPS/page006.svg" ]
+    "referencedItems" : [ "OPS/page001.xhtml", "OPS/page002.xhtml", "OPS/page003.xhtml", "OPS/page004.xhtml", "OPS/page005.svg", "OPS/page005.xhtml", "OPS/page006.svg", "OPS/page007.svg", "OPS/page008.svg" ]
   } ],
   "messages" : [ {
     "ID" : "ACC-007",

--- a/src/test/resources/com/adobe/epubcheck/test/package/image_types_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/package/image_types_expected_results.json
@@ -1,11 +1,11 @@
 {
   "customMessageFileName" : null,
   "checker" : {
-    "path" : "./com/adobe/epubcheck/test/package/image_types.epub",
+    "path" : "./target/test-classes/com/adobe/epubcheck/test/package/image_types.epub",
     "filename" : "image_types.epub",
-    "checkerVersion" : "4.0.0-alpha11-SNAPSHOT",
-    "checkDate" : "09-05-2014 03:15:56",
-    "elapsedTime" : 1119,
+    "checkerVersion" : "4.0.0-alpha12-SNAPSHOT",
+    "checkDate" : "03-25-2015 10:06:21",
+    "elapsedTime" : 653,
     "nFatal" : 0,
     "nError" : 0,
     "nWarning" : 1,
@@ -258,7 +258,7 @@
     "renditionLayout" : "reflowable",
     "renditionOrientation" : "auto",
     "renditionSpread" : "auto",
-    "referencedItems" : [ "OPS/images/PrincessBrideReunion.png", "OPS/images/BigRed.png", "OPS/images/kitty.jpeg", "OPS/images/PlaceHolder.gif", "OPS/images/PlaceHolder.png" ]
+    "referencedItems" : [ "OPS/images/BigRed.png", "OPS/images/PlaceHolder.gif", "OPS/images/PlaceHolder.png", "OPS/images/PrincessBrideReunion.png", "OPS/images/kitty.jpeg" ]
   }, {
     "id" : "toc",
     "fileName" : "OPS/toc.xhtml",

--- a/src/test/resources/com/adobe/epubcheck/test/package/path_resolution_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/package/path_resolution_expected_results.json
@@ -1,11 +1,11 @@
 {
   "customMessageFileName" : null,
   "checker" : {
-    "path" : "./com/adobe/epubcheck/test/package/path_resolution.epub",
+    "path" : "./target/test-classes/com/adobe/epubcheck/test/package/path_resolution.epub",
     "filename" : "path_resolution.epub",
-    "checkerVersion" : "4.0.0-alpha11-SNAPSHOT",
-    "checkDate" : "09-05-2014 03:15:57",
-    "elapsedTime" : 321,
+    "checkerVersion" : "4.0.0-alpha12-SNAPSHOT",
+    "checkDate" : "03-25-2015 10:19:29",
+    "elapsedTime" : 196,
     "nFatal" : 0,
     "nError" : 0,
     "nWarning" : 0,
@@ -324,7 +324,7 @@
     "renditionLayout" : "reflowable",
     "renditionOrientation" : "auto",
     "renditionSpread" : "auto",
-    "referencedItems" : [ "A.xhtml", "OPS/MathML1.xhtml", "OPS/Description.xhtml", "MathML2.xhtml" ]
+    "referencedItems" : [ "A.xhtml", "MathML2.xhtml", "OPS/Description.xhtml", "OPS/MathML1.xhtml" ]
   } ],
   "messages" : [ {
     "ID" : "ACC-007",

--- a/src/test/resources/com/adobe/epubcheck/test/package/wrong_extension_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/package/wrong_extension_expected_results.json
@@ -1,11 +1,11 @@
 {
   "customMessageFileName" : null,
   "checker" : {
-    "path" : "./com/adobe/epubcheck/test/package/wrong_extension.zip",
+    "path" : "./target/test-classes/com/adobe/epubcheck/test/package/wrong_extension.zip",
     "filename" : "wrong_extension.zip",
-    "checkerVersion" : "4.0.0-alpha11-SNAPSHOT",
-    "checkDate" : "09-05-2014 03:15:58",
-    "elapsedTime" : 46,
+    "checkerVersion" : "4.0.0-alpha12-SNAPSHOT",
+    "checkDate" : "03-25-2015 10:19:29",
+    "elapsedTime" : 21,
     "nFatal" : 0,
     "nError" : 0,
     "nWarning" : 2,
@@ -148,7 +148,7 @@
     "renditionLayout" : "reflowable",
     "renditionOrientation" : "auto",
     "renditionSpread" : "auto",
-    "referencedItems" : [ "OPS/LinkTarget1.xhtml", "OPS/images/ColorStripes.png", "OPS/LinkTarget2.xhtml" ]
+    "referencedItems" : [ "OPS/LinkTarget1.xhtml", "OPS/LinkTarget2.xhtml", "OPS/images/ColorStripes.png" ]
   }, {
     "id" : "pg02",
     "fileName" : "OPS/FillerPage.xhtml",

--- a/src/test/resources/com/adobe/epubcheck/test/scripts/unused_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/scripts/unused_expected_results.json
@@ -1,11 +1,11 @@
 {
   "customMessageFileName" : null,
   "checker" : {
-    "path" : "./com/adobe/epubcheck/test/scripts/unused.epub",
+    "path" : "./target/test-classes/com/adobe/epubcheck/test/scripts/unused.epub",
     "filename" : "unused.epub",
-    "checkerVersion" : "4.0.0-alpha11-SNAPSHOT",
-    "checkDate" : "09-05-2014 03:16:19",
-    "elapsedTime" : 103,
+    "checkerVersion" : "4.0.0-alpha12-SNAPSHOT",
+    "checkDate" : "03-25-2015 10:06:34",
+    "elapsedTime" : 50,
     "nFatal" : 0,
     "nError" : 0,
     "nWarning" : 0,
@@ -170,7 +170,7 @@
     "renditionLayout" : "reflowable",
     "renditionOrientation" : "auto",
     "renditionSpread" : "auto",
-    "referencedItems" : [ "OPS/unused.js", "OPS/sample.js" ]
+    "referencedItems" : [ "OPS/sample.js", "OPS/unused.js" ]
   }, {
     "id" : "page03",
     "fileName" : "OPS/script_tag.xhtml",

--- a/src/test/resources/com/adobe/epubcheck/test/toc/fragments_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/toc/fragments_expected_results.json
@@ -1,11 +1,11 @@
 {
   "customMessageFileName" : null,
   "checker" : {
-    "path" : "./com/adobe/epubcheck/test/toc/fragments.epub",
+    "path" : "./target/test-classes/com/adobe/epubcheck/test/toc/fragments.epub",
     "filename" : "fragments.epub",
-    "checkerVersion" : "4.0.0-alpha11-SNAPSHOT",
-    "checkDate" : "09-05-2014 03:16:23",
-    "elapsedTime" : 90,
+    "checkerVersion" : "4.0.0-alpha12-SNAPSHOT",
+    "checkDate" : "03-25-2015 10:06:36",
+    "elapsedTime" : 46,
     "nFatal" : 0,
     "nError" : 0,
     "nWarning" : 0,
@@ -192,7 +192,7 @@
     "renditionLayout" : null,
     "renditionOrientation" : null,
     "renditionSpread" : null,
-    "referencedItems" : [ "OPS/page02.xhtml", "OPS/page01.xhtml" ]
+    "referencedItems" : [ "OPS/page01.xhtml", "OPS/page02.xhtml" ]
   } ],
   "messages" : [ {
     "ID" : "ACC-007",

--- a/src/test/resources/com/adobe/epubcheck/test/toc/invalid_ncx_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/toc/invalid_ncx_expected_results.json
@@ -1,11 +1,11 @@
 {
   "customMessageFileName" : null,
   "checker" : {
-    "path" : "./com/adobe/epubcheck/test/toc/invalid_ncx.epub",
+    "path" : "./target/test-classes/com/adobe/epubcheck/test/toc/invalid_ncx.epub",
     "filename" : "invalid_ncx.epub",
-    "checkerVersion" : "4.0.0-alpha11-SNAPSHOT",
-    "checkDate" : "09-05-2014 03:16:23",
-    "elapsedTime" : 82,
+    "checkerVersion" : "4.0.0-alpha12-SNAPSHOT",
+    "checkDate" : "03-25-2015 10:06:36",
+    "elapsedTime" : 41,
     "nFatal" : 0,
     "nError" : 3,
     "nWarning" : 1,
@@ -126,7 +126,7 @@
     "renditionLayout" : null,
     "renditionOrientation" : null,
     "renditionSpread" : null,
-    "referencedItems" : [ "OPS/toc.xhtml", "OPS/page01.xhtml" ]
+    "referencedItems" : [ "OPS/page01.xhtml", "OPS/toc.xhtml" ]
   }, {
     "id" : "page01",
     "fileName" : "OPS/page01.xhtml",

--- a/src/test/resources/com/adobe/epubcheck/test/xhtml/External_media_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/xhtml/External_media_expected_results.json
@@ -1,11 +1,11 @@
 {
   "customMessageFileName" : null,
   "checker" : {
-    "path" : "./com/adobe/epubcheck/test/xhtml/External_media.epub",
+    "path" : "./target/test-classes/com/adobe/epubcheck/test/xhtml/External_media.epub",
     "filename" : "External_media.epub",
-    "checkerVersion" : "4.0.0-alpha11-SNAPSHOT",
-    "checkDate" : "09-05-2014 03:16:28",
-    "elapsedTime" : 105,
+    "checkerVersion" : "4.0.0-alpha12-SNAPSHOT",
+    "checkDate" : "03-25-2015 10:06:39",
+    "elapsedTime" : 47,
     "nFatal" : 0,
     "nError" : 0,
     "nWarning" : 0,
@@ -280,7 +280,7 @@
     "renditionLayout" : null,
     "renditionOrientation" : null,
     "renditionSpread" : null,
-    "referencedItems" : [ "OPS/video.xhtml", "OPS/audio.xhtml" ]
+    "referencedItems" : [ "OPS/audio.xhtml", "OPS/video.xhtml" ]
   } ],
   "messages" : [ {
     "ID" : "ACC-007",

--- a/src/test/resources/com/adobe/epubcheck/test/xhtml/hyperlinks_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/xhtml/hyperlinks_expected_results.json
@@ -1,11 +1,11 @@
 {
   "customMessageFileName" : null,
   "checker" : {
-    "path" : "./com/adobe/epubcheck/test/xhtml/hyperlinks.epub",
+    "path" : "./target/test-classes/com/adobe/epubcheck/test/xhtml/hyperlinks.epub",
     "filename" : "hyperlinks.epub",
-    "checkerVersion" : "4.0.0-alpha11-SNAPSHOT",
-    "checkDate" : "09-05-2014 03:16:27",
-    "elapsedTime" : 120,
+    "checkerVersion" : "4.0.0-alpha12-SNAPSHOT",
+    "checkDate" : "03-25-2015 10:06:39",
+    "elapsedTime" : 64,
     "nFatal" : 0,
     "nError" : 8,
     "nWarning" : 2,
@@ -148,7 +148,7 @@
     "renditionLayout" : "reflowable",
     "renditionOrientation" : "auto",
     "renditionSpread" : "auto",
-    "referencedItems" : [ "OPS/style.css", "OPS/images/sample.jpg", "OPS/svg_links.xhtml", "OPS/link_target.xhtml", "OPS/" ]
+    "referencedItems" : [ "OPS/", "OPS/images/sample.jpg", "OPS/link_target.xhtml", "OPS/style.css", "OPS/svg_links.xhtml" ]
   }, {
     "id" : "page02",
     "fileName" : "OPS/link_target.xhtml",

--- a/src/test/resources/com/adobe/epubcheck/test/xhtml/media_overlays_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/xhtml/media_overlays_expected_results.json
@@ -1,11 +1,11 @@
 {
   "customMessageFileName" : null,
   "checker" : {
-    "path" : "./com/adobe/epubcheck/test/xhtml/media_overlays.epub",
+    "path" : "./target/test-classes/com/adobe/epubcheck/test/xhtml/media_overlays.epub",
     "filename" : "media_overlays.epub",
-    "checkerVersion" : "4.0.0-alpha11-SNAPSHOT",
-    "checkDate" : "09-05-2014 03:16:28",
-    "elapsedTime" : 802,
+    "checkerVersion" : "4.0.0-alpha12-SNAPSHOT",
+    "checkDate" : "03-25-2015 14:49:51",
+    "elapsedTime" : 3500,
     "nFatal" : 0,
     "nError" : 3,
     "nWarning" : 0,
@@ -104,7 +104,7 @@
     "renditionLayout" : null,
     "renditionOrientation" : null,
     "renditionSpread" : null,
-    "referencedItems" : [ "OPS/chapter_001.xhtml", "OPS/audio/mobydick_001_002_melville.mp4" ]
+    "referencedItems" : [ "OPS/audio/mobydick_001_002_melville.mp4", "OPS/chapter_001.xhtml" ]
   }, {
     "id" : "ePubCheck.NoManifestRef:META-INF/container.xml",
     "fileName" : "META-INF/container.xml",
@@ -324,7 +324,7 @@
     "renditionLayout" : null,
     "renditionOrientation" : null,
     "renditionSpread" : null,
-    "referencedItems" : [ "OPS/page01.xhtml", "OPS/audio/echild_s01_all.m4a" ]
+    "referencedItems" : [ "OPS/audio/echild_s01_all.m4a", "OPS/page01.xhtml" ]
   }, {
     "id" : "style",
     "fileName" : "OPS/css/stylesheet.css",
@@ -346,7 +346,7 @@
     "renditionLayout" : null,
     "renditionOrientation" : null,
     "renditionSpread" : null,
-    "referencedItems" : [ "OPS/fonts/iwonacond-bolditalic.otf", "OPS/fonts/iwonacond-bold.otf", "OPS/fonts/iwonacond-italic.otf", "OPS/fonts/iwonacond-regular.otf" ]
+    "referencedItems" : [ "OPS/fonts/iwonacond-bold.otf", "OPS/fonts/iwonacond-bolditalic.otf", "OPS/fonts/iwonacond-italic.otf", "OPS/fonts/iwonacond-regular.otf" ]
   }, {
     "id" : "toc",
     "fileName" : "OPS/toc.xhtml",
@@ -477,6 +477,11 @@
       "context" : ".dedication-rw"
     }, {
       "fileName" : "OPS/css/stylesheet.css",
+      "line" : 78,
+      "column" : 1,
+      "context" : ".Dedication-rw"
+    }, {
+      "fileName" : "OPS/css/stylesheet.css",
       "line" : 82,
       "column" : 1,
       "context" : ".leading-line-rw"
@@ -485,6 +490,11 @@
       "line" : 86,
       "column" : 1,
       "context" : ".fp-rw"
+    }, {
+      "fileName" : "OPS/css/stylesheet.css",
+      "line" : 115,
+      "column" : 1,
+      "context" : ".title-author-rw"
     }, {
       "fileName" : "OPS/css/stylesheet.css",
       "line" : 121,
@@ -520,6 +530,11 @@
       "line" : 174,
       "column" : 5,
       "context" : ".dropcap-rw"
+    }, {
+      "fileName" : "OPS/css/stylesheet.css",
+      "line" : 181,
+      "column" : 1,
+      "context" : ".signature-rw"
     }, {
       "fileName" : "OPS/css/stylesheet.css",
       "line" : 187,
@@ -570,21 +585,6 @@
       "line" : 312,
       "column" : 5,
       "context" : ".source-rw"
-    }, {
-      "fileName" : "OPS/css/stylesheet.css",
-      "line" : 327,
-      "column" : 1,
-      "context" : ".list-simple-rw"
-    }, {
-      "fileName" : "OPS/css/stylesheet.css",
-      "line" : 338,
-      "column" : 4,
-      "context" : ".photo"
-    }, {
-      "fileName" : "OPS/css/stylesheet.css",
-      "line" : 358,
-      "column" : 1,
-      "context" : ".-epub-media-overlay-active"
     }, {
       "fileName" : "There are 3 additional locations for this message.",
       "line" : -1,


### PR DESCRIPTION
- replace HashMap instances with LinkedHashMap when the order matters
- replace HashSet instances with TreeSet when the order matters
- add some (deprecated) OEBPS 1.2 XHTML DTD (referenced in some test)
- Fix/adapt some tests

Close #364