### PR TITLE
Fix the compilation of ValidatorMap on Java 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: java
+jdk:
+  - oraclejdk8
+  - oraclejdk7
+  - openjdk6
 before_install: .travis/before_install.sh
 script: mvn verify
 after_success: .travis/after_success.sh


### PR DESCRIPTION
- loosen the generics restriction of method signatures
- add a jdk build matrix to the Travis config to make it compile on Java 6, 7 & 8