### PR TITLE
Re-enable runtime support for Java 6

### DIFF
--- a/src/main/java/com/adobe/epubcheck/bitmap/BitmapChecker.java
+++ b/src/main/java/com/adobe/epubcheck/bitmap/BitmapChecker.java
@@ -261,6 +261,9 @@ public class BitmapChecker implements ContentChecker
     catch (IOException ex)
     {
       report.message(MessageId.PKG_021, EPUBLocation.create(imageFileName) );
+    } catch (LinkageError error)
+    {
+      report.message(MessageId.RSC_022, EPUBLocation.create(imageFileName));
     }
   }
 

--- a/src/main/java/com/adobe/epubcheck/messages/MessageDictionary.java
+++ b/src/main/java/com/adobe/epubcheck/messages/MessageDictionary.java
@@ -328,6 +328,7 @@ public class MessageDictionary
       map.put(MessageId.RSC_019, Severity.WARNING);
       map.put(MessageId.RSC_020, Severity.ERROR);
       map.put(MessageId.RSC_021, Severity.ERROR);
+      map.put(MessageId.RSC_022, Severity.INFO);
 
       // Scripting
       map.put(MessageId.SCP_001, Severity.USAGE);

--- a/src/main/java/com/adobe/epubcheck/messages/MessageId.java
+++ b/src/main/java/com/adobe/epubcheck/messages/MessageId.java
@@ -291,6 +291,7 @@ public enum MessageId implements Comparable<MessageId>
   RSC_019("RSC-019"),
   RSC_020("RSC-020"),
   RSC_021("RSC-021"),
+  RSC_022("RSC-022"),
 
   // Messages relating to scripting
   SCP_001("SCP-001"),

--- a/src/main/resources/com/adobe/epubcheck/messages/MessageBundle.properties
+++ b/src/main/resources/com/adobe/epubcheck/messages/MessageBundle.properties
@@ -291,7 +291,8 @@ RSC_017=Warning while parsing file '%1$s'.
 RSC_018=Altimg file '%1$s' could not be found.
 RSC_019=EPUBs with Multiple Renditions should contain a META-INF/metadata.xml file.  
 RSC_020='%1$s' is not a valid URI. 
-RSC_021=A Search Key Map Document must point to Content Documents ('%1s' was not found in the spine). 
+RSC_021=A Search Key Map Document must point to Content Documents ('%1s' was not found in the spine).
+RSC_022=Cannot check image details (requires Java version 7 or higher). 
 
 #Scripting
 SCP_001=Use of Javascript eval() function in EPUB scripts is a security risk.

--- a/src/test/java/com/adobe/epubcheck/test/message_coverage.java
+++ b/src/test/java/com/adobe/epubcheck/test/message_coverage.java
@@ -9,11 +9,11 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
-import junit.framework.Assert;
-
 import org.junit.Test;
 
 import com.adobe.epubcheck.messages.MessageId;
+
+import junit.framework.Assert;
 
 /**
  * Test the coverage of reported message ids by all the tests.  This test should run after all the others have completed.
@@ -53,6 +53,7 @@ public class message_coverage
     expectedMissedCoverage.add(MessageId.PKG_005); //This is only reported in an exception that is difficult to generate in a test
     expectedMissedCoverage.add(MessageId.PKG_015); //This is only reported in an exception that is difficult to generate in a test
     expectedMissedCoverage.add(MessageId.PKG_023); //TODO add tests
+    expectedMissedCoverage.add(MessageId.RSC_022); //If a LinkageError happens when running Java 6
 
     Assert.assertEquals("Messages not covered by tests", expectedMissedCoverage, allMessages);
   }


### PR DESCRIPTION
When running Java 6, any `LinkageError` thrown at runtime due to
incompatibility of the TwelveMonkeys ImageIO plugin is caught and
an info message is displayed.

Note: building on Java 6 remains unsupported (some tests fail due to
lesser image checking).