### PR TITLE
fix typo of error messages for listings

### DIFF
--- a/src/main/resources/com/adobe/epubcheck/messages/MessageBundle.properties
+++ b/src/main/resources/com/adobe/epubcheck/messages/MessageBundle.properties
@@ -135,9 +135,9 @@ NAV_002=Found epub:type="page-list" in nav document
 NAV_003=The Navigation Document must have a page list when content document(s) contain page breaks (epub:type="pagebreak").
 NAV_004=The Navigation Document should contain the full document heading hierarchy in EDUPUB.
 NAV_005=Content documents contain 'audio' elements but the Navigation Document does not have a listing of audio clips (epub:type="loa").
-NAV_006=Content documents contain 'audio' elements but the Navigation Document does not have a listing of figures (epub:type="loi").
-NAV_007=Content documents contain 'audio' elements but the Navigation Document does not have a listing of tables (epub:type="lot").
-NAV_008=Content documents contain 'audio' elements but the Navigation Document does not have a listing of video clips (epub:type="lov").
+NAV_006=Content documents contain 'figure' elements but the Navigation Document does not have a listing of figures (epub:type="loi").
+NAV_007=Content documents contain 'table' elements but the Navigation Document does not have a listing of tables (epub:type="lot").
+NAV_008=Content documents contain 'video' elements but the Navigation Document does not have a listing of video clips (epub:type="lov").
 NAV_009=Region-based navigation links must point to Fixed-Layout Documents.
 
 #NCX EPUB v2 Table of Contents


### PR DESCRIPTION
These messages are used at: https://github.com/IDPF/epubcheck/blob/master/src/main/java/com/adobe/epubcheck/opf/OPFChecker30.java#L423-L446