### PR TITLE
Fix ns validation issue in NVDLs

### DIFF
--- a/src/main/resources/com/adobe/epubcheck/schema/30/media-overlay-30.nvdl
+++ b/src/main/resources/com/adobe/epubcheck/schema/30/media-overlay-30.nvdl
@@ -2,8 +2,8 @@
 <rules xmlns="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0" startMode="smil">
     <mode name="smil">
         <namespace ns="http://www.w3.org/ns/SMIL">
-            <validate schema="media-overlay-30.rnc" schemaType="application/relax-ng-compact-syntax"/>
-            <validate schema="media-overlay-30.sch"/>
+            <validate schema="media-overlay-30.rnc" schemaType="application/relax-ng-compact-syntax" useMode="attach"/>
+            <validate schema="media-overlay-30.sch" useMode="attach"/>
         </namespace>
     </mode>
     <mode name="attach">

--- a/src/main/resources/com/adobe/epubcheck/schema/30/ocf-container-30.nvdl
+++ b/src/main/resources/com/adobe/epubcheck/schema/30/ocf-container-30.nvdl
@@ -2,8 +2,8 @@
 <rules xmlns="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0" startMode="package">
 	<mode name="package">
 		<namespace ns="urn:oasis:names:tc:opendocument:xmlns:container">
-			<validate schema="ocf-container-30.rnc" schemaType="application/relax-ng-compact-syntax"/>
-			<validate schema="multiple-renditions/container.sch"/>
+			<validate schema="ocf-container-30.rnc" schemaType="application/relax-ng-compact-syntax" useMode="attach"/>
+			<validate schema="multiple-renditions/container.sch" useMode="attach"/>
 		</namespace>
 	</mode>
 	<mode name="attach">

--- a/src/main/resources/com/adobe/epubcheck/schema/30/ocf-metadata-30.nvdl
+++ b/src/main/resources/com/adobe/epubcheck/schema/30/ocf-metadata-30.nvdl
@@ -2,8 +2,8 @@
 <rules xmlns="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0" startMode="package">
 	<mode name="package">
 		<namespace ns="http://www.idpf.org/2013/metadata">
-			<validate schema="ocf-metadata-30.rnc" schemaType="application/relax-ng-compact-syntax"/>
-			<validate schema="ocf-metadata-30.sch"/>
+			<validate schema="ocf-metadata-30.rnc" schemaType="application/relax-ng-compact-syntax" useMode="attach"/>
+			<validate schema="ocf-metadata-30.sch" useMode="attach"/>
 		</namespace>
 	</mode>
 	<mode name="attach">

--- a/src/main/resources/com/adobe/epubcheck/schema/30/package-30.nvdl
+++ b/src/main/resources/com/adobe/epubcheck/schema/30/package-30.nvdl
@@ -2,8 +2,8 @@
 <rules xmlns="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0" startMode="package">
     <mode name="package">
         <namespace ns="http://www.idpf.org/2007/opf">
-            <validate schema="package-30.rnc" schemaType="application/relax-ng-compact-syntax"/>
-            <validate schema="package-30.sch"/>
+            <validate schema="package-30.rnc" schemaType="application/relax-ng-compact-syntax"  useMode="attach"/>
+            <validate schema="package-30.sch" useMode="attach"/>
         </namespace>
     </mode>
     <mode name="attach">


### PR DESCRIPTION
See issue #601 for details.

Note: NVDL schemas are currently not used by EpubCheck, but this fix
at least make them usable by 3d party tools.

Fixes #601.