### PR TITLE
Fix case insensitive check of XHTML encoding declaration

### DIFF
--- a/src/main/resources/com/adobe/epubcheck/schema/30/epub-xhtml-30.sch
+++ b/src/main/resources/com/adobe/epubcheck/schema/30/epub-xhtml-30.sch
@@ -12,7 +12,7 @@
 
     <pattern id="encoding.decl.state">
         <rule context="h:meta[lower-case(@http-equiv)='content-type']">
-            <assert test="matches(normalize-space(@content),'text/html;\s*charset=utf-8',i)">The
+            <assert test="matches(normalize-space(@content),'text/html;\s*charset=utf-8','i')">The
                 meta element in encoding declaration state (http-equiv='content-type') must have the
                 value 'text/html; charset=utf-8'</assert>
             <assert test="empty(../h:meta[@charset])">A document must not contain both a meta element

--- a/src/test/java/com/adobe/epubcheck/ops/OPSCheckerTest.java
+++ b/src/test/java/com/adobe/epubcheck/ops/OPSCheckerTest.java
@@ -475,17 +475,24 @@ public class OPSCheckerTest
   }
 
   @Test
-  public void testValidateXHTML_httpequiv1()
+  public void testValidateXHTML_httpequiv()
+  {
+      testValidateDocument("xhtml/valid/http-equiv-1.xhtml", "application/xhtml+xml",
+              EPUBVersion.VERSION_3);
+  }
+  
+  @Test
+  public void testValidateXHTML_httpequiv_caseinsensitive()
+  {
+      testValidateDocument("xhtml/valid/http-equiv-2.xhtml", "application/xhtml+xml",
+              EPUBVersion.VERSION_3,true);
+  }
+  
+  @Test
+  public void testValidateXHTML_httpequiv_invalid()
   {
     Collections.addAll(expectedErrors, MessageId.RSC_005);
     testValidateDocument("xhtml/invalid/http-equiv-1.xhtml", "application/xhtml+xml",
-        EPUBVersion.VERSION_3);
-  }
-
-  @Test
-  public void testValidateXHTML_httpequiv2()
-  {
-    testValidateDocument("xhtml/valid/http-equiv-1.xhtml", "application/xhtml+xml",
         EPUBVersion.VERSION_3);
   }
 

--- a/src/test/resources/30/single/xhtml/valid/http-equiv-2.xhtml
+++ b/src/test/resources/30/single/xhtml/valid/http-equiv-2.xhtml
@@ -1,0 +1,17 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">
+   <head>	
+      <meta http-equiv="Default-Style" content="foo" />
+	  <meta http-equiv="Refresh" content="300" />
+      <meta http-equiv="Content-Type" content="Text/HTML; Charset=UTF-8" />
+      <title>TOC</title>
+   </head>
+   <body>
+      <nav epub:type="toc" id="toc">
+         <ol>
+            <li>
+               <a href="navigation.xhtml#toc">TOC</a>
+            </li>
+         </ol>
+      </nav>
+   </body>
+</html>


### PR DESCRIPTION
An HTML meta element with `http-equiv` in character encoding declaration
state must be parsed in a case insensitive manner.
This commit fixes a Schematron typo (the `'i'` parameter of the `matches`
function was unquoted, hence evaluated as an empty sequence instead
of a string, which was consequently ignored) to propertly enable a
case-insenstive comparison.

Fixes #603