### PR TITLE
Ignore explicit declarations of reserved prefixes

### DIFF
--- a/src/main/java/com/adobe/epubcheck/vocab/AggregateVocab.java
+++ b/src/main/java/com/adobe/epubcheck/vocab/AggregateVocab.java
@@ -3,13 +3,23 @@ package com.adobe.epubcheck.vocab;
 import java.util.List;
 
 import com.google.common.base.Optional;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 
 public class AggregateVocab implements Vocab
 {
 
   private final List<Vocab> vocabs;
+  private final String uri;
 
+  /**
+   * Returns a vocabulary composed of the union of the vocabularies given as
+   * parameter. The given vocabularies must have the same base URI.
+   * 
+   * @param vocabs
+   *          the vocabularies to aggregate.
+   * @return the aggregated vocabulary.
+   */
   public static Vocab of(Vocab... vocabs)
   {
     return new AggregateVocab(new ImmutableList.Builder<Vocab>().add(vocabs).build());
@@ -17,6 +27,14 @@ public class AggregateVocab implements Vocab
 
   private AggregateVocab(List<Vocab> vocabs)
   {
+    this.uri = (!vocabs.isEmpty()) ? Strings.nullToEmpty(vocabs.get(0).getURI()) : "";
+    for (Vocab vocab : vocabs)
+    {
+      if (!uri.equals(Strings.nullToEmpty(vocab.getURI())))
+      {
+        throw new IllegalArgumentException("Aggregated vocabs must share the same base URI");
+      }
+    }
     this.vocabs = vocabs;
   }
 
@@ -29,6 +47,12 @@ public class AggregateVocab implements Vocab
       if (found.isPresent()) return found;
     }
     return Optional.absent();
+  }
+
+  @Override
+  public String getURI()
+  {
+    return uri;
   }
 
 }

--- a/src/main/java/com/adobe/epubcheck/vocab/EnumVocab.java
+++ b/src/main/java/com/adobe/epubcheck/vocab/EnumVocab.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Maps.EntryTransformer;
@@ -39,6 +40,7 @@ public final class EnumVocab<P extends Enum<P>> implements Vocab
   };
 
   private final Map<String, Property> index;
+  private final String uri;
 
   /**
    * Creates a new vocabulary backed by the given {@link Enum} class and with
@@ -70,24 +72,31 @@ public final class EnumVocab<P extends Enum<P>> implements Vocab
    */
   public EnumVocab(final Class<P> clazz, final String base, final String prefix)
   {
-    this.index = ImmutableMap.copyOf(Maps.transformEntries(
-        Maps.uniqueIndex(EnumSet.allOf(clazz), ENUM_TO_NAME),
-        new EntryTransformer<String, P, Property>()
-        {
+    this.uri = Strings.nullToEmpty(base);
+    this.index = ImmutableMap
+        .copyOf(Maps.transformEntries(Maps.uniqueIndex(EnumSet.allOf(clazz), ENUM_TO_NAME),
+            new EntryTransformer<String, P, Property>()
+            {
 
-          @Override
-          public Property transformEntry(String name, P enumee)
-          {
-            return Property.newFrom(name, base, prefix, enumee);
-          }
+              @Override
+              public Property transformEntry(String name, P enumee)
+              {
+                return Property.newFrom(name, base, prefix, enumee);
+              }
 
-        }));
+            }));
   }
 
   @Override
   public Optional<Property> lookup(String name)
   {
     return Optional.fromNullable(index.get(name));
+  }
+
+  @Override
+  public String getURI()
+  {
+    return uri;
   }
 
   /**

--- a/src/main/java/com/adobe/epubcheck/vocab/UncheckedVocab.java
+++ b/src/main/java/com/adobe/epubcheck/vocab/UncheckedVocab.java
@@ -14,8 +14,8 @@ import com.google.common.base.Optional;
 public final class UncheckedVocab implements Vocab
 {
 
-  private String base;
-  private String prefix;
+  private final String base;
+  private final String prefix;
 
   /**
    * Creates a new unchecked vocabulary representing properties whose URIs start
@@ -42,6 +42,12 @@ public final class UncheckedVocab implements Vocab
   public Optional<Property> lookup(String name)
   {
     return Optional.of(Property.newFrom(name, base, prefix));
+  }
+
+  @Override
+  public String getURI()
+  {
+    return base;
   }
 
 }

--- a/src/main/java/com/adobe/epubcheck/vocab/Vocab.java
+++ b/src/main/java/com/adobe/epubcheck/vocab/Vocab.java
@@ -20,4 +20,11 @@ public interface Vocab
    *         in this vocabulary.
    */
   Optional<Property> lookup(String name);
+
+  /**
+   * Returns the base URI of this vocabulary.
+   * 
+   * @return the base URI of this vocabulary.
+   */
+  String getURI();
 }

--- a/src/main/java/com/adobe/epubcheck/vocab/VocabUtil.java
+++ b/src/main/java/com/adobe/epubcheck/vocab/VocabUtil.java
@@ -55,8 +55,8 @@ public final class VocabUtil
       Report report, EPUBLocation location)
   {
 
-    return Optional.fromNullable(Iterables.get(
-        parseProperties(value, vocabs, false, report, location), 0, null));
+    return Optional.fromNullable(
+        Iterables.get(parseProperties(value, vocabs, false, report, location), 0, null));
   }
 
   /**
@@ -198,7 +198,8 @@ public final class VocabUtil
       }
       else
       {
-        if (predefined.containsKey(prefix))
+        if (predefined.containsKey(prefix)
+            && !Strings.nullToEmpty(predefined.get(prefix).getURI()).equals(uri))
         {
           // re-declaration of reserved prefix
           report.message(MessageId.OPF_007, location, prefix);

--- a/src/test/java/com/adobe/epubcheck/opf/OPFCheckerTest.java
+++ b/src/test/java/com/adobe/epubcheck/opf/OPFCheckerTest.java
@@ -487,7 +487,7 @@ public class OPFCheckerTest
   @Test
   public void testValidateRedeclaredReservedPrefixes()
   {
-    Collections.addAll(expectedWarnings, MessageId.OPF_007, MessageId.OPF_007, MessageId.OPF_007b,
+    Collections.addAll(expectedWarnings, MessageId.OPF_007, MessageId.OPF_007b,
         MessageId.OPF_007b);
     // should generate 2 warnings (redeclaration of reserved prefixes and
     // redeclaration of default vocab)

--- a/src/test/resources/30/single/opf/invalid/prefixes-redeclare.opf
+++ b/src/test/resources/30/single/opf/invalid/prefixes-redeclare.opf
@@ -1,11 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="uid"
 		prefix="media: http://should/not/redeclare
-		        rendition: http://should/not/redeclare/too
+		        rendition: http://www.idpf.org/vocab/rendition/#
 		        foo: http://idpf.org/epub/vocab/package/#
 		        bar: http://idpf.org/epub/vocab/package/link/#">
 				
-	<!-- redeclaring 2 reserved prefixes -->			
+	<!-- redeclaring 2 reserved prefixes: 
+	     - 'media' raises an error since it's redeclared to another vocab
+	     - 'rendition' is ignored since it only re-declares the reserved vocab
+	-->			
 				
     <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
         <dc:identifier id="uid">urn:uuid:550e8400-e29b-41d4-a716-4466674412314</dc:identifier>


### PR DESCRIPTION
- added a new method to `Vocab` to get the base URI of a vocabulary
- In the prefix parsing utility of `VocabUtil`, check the URI associated
  with re-declared reserved prefix: an error is reported only if this
  URI is **not** the URI of the known vocabulary associated to the
  reserved prefix. In other words, explicit declaration of reserved
  prefixes is now allowed; trying to override a reserved prefix still
  raises an error.

Fixes #585