### PR TITLE
Avoid duplicate PKG-008 or RSC-005 XML parsing errors

### DIFF
--- a/src/main/java/com/adobe/epubcheck/ctc/XmlDocParser.java
+++ b/src/main/java/com/adobe/epubcheck/ctc/XmlDocParser.java
@@ -63,11 +63,15 @@ class XmlDocParser
     }
     catch (IOException e)
     {
-      report.message(MessageId.PKG_008, EPUBLocation.create(fileEntry), fileEntry);
+      // Ignore, should have been reported earlier
+      // report.message(MessageId.PKG_008, EPUBLocation.create(fileEntry),
+      // fileEntry);
     }
     catch (SAXException e)
     {
-      report.message(MessageId.RSC_005, EPUBLocation.create(fileEntry), e.getMessage());
+      // Ignore, should have been reported earlier
+      // report.message(MessageId.RSC_005, EPUBLocation.create(fileEntry),
+      // e.getMessage());
       doc = null;
     }
     finally

--- a/src/main/java/com/adobe/epubcheck/ctc/xml/XMLContentDocParser.java
+++ b/src/main/java/com/adobe/epubcheck/ctc/xml/XMLContentDocParser.java
@@ -70,11 +70,15 @@ public class XMLContentDocParser
     }
     catch (IOException e)
     {
-      report.message(MessageId.PKG_008, EPUBLocation.create(fileEntry), fileEntry);
+      // Ignore, should have been reported earlier
+      // report.message(MessageId.PKG_008, EPUBLocation.create(fileEntry),
+      // fileEntry);
     }
     catch (SAXException e)
     {
-      report.message(MessageId.RSC_005, EPUBLocation.create(fileEntry), e.getMessage());
+      // Ignore, should have been reported earlier
+      // report.message(MessageId.RSC_005, EPUBLocation.create(fileEntry),
+      // e.getMessage());
     }
     catch (ParserConfigurationException e)
     {

--- a/src/test/java/com/adobe/epubcheck/api/Epub20CheckTest.java
+++ b/src/test/java/com/adobe/epubcheck/api/Epub20CheckTest.java
@@ -85,7 +85,6 @@ public class Epub20CheckTest extends AbstractEpubCheckTest
   @Test
   public void testValidateEPUBPFileDeclaredInContainerNotOpf20()
   {
-    Collections.addAll(expectedErrors, MessageId.RSC_005);
     testValidateDocument("ContainerNotOPF20.epub");
   }
 

--- a/src/test/java/com/adobe/epubcheck/api/Epub30CheckExpandedTest.java
+++ b/src/test/java/com/adobe/epubcheck/api/Epub30CheckExpandedTest.java
@@ -1017,10 +1017,17 @@ public class Epub30CheckExpandedTest extends AbstractEpubCheckTest
   }
 
   @Test
+  public void testEncryption_Unknown(){
+    expectedErrors.add(MessageId.RSC_004);
+    testValidateDocument("invalid/encryption-unknown");
+  }
+  
+  @Test
   public void testOutOfSpineRef()
   {
     expectedErrors.add(MessageId.RSC_011);
     testValidateDocument("invalid/href-outofspine");
   }
+  
 
 }

--- a/src/test/resources/30/expanded/invalid/encryption-unknown/EPUB/lorem.css
+++ b/src/test/resources/30/expanded/invalid/encryption-unknown/EPUB/lorem.css
@@ -1,0 +1,6 @@
+body {
+    margin-left : 6em;
+    margin-right : 16em;
+    color:black;
+    font-family: arial, helvetica, sans-serif;
+}

--- a/src/test/resources/30/expanded/invalid/encryption-unknown/EPUB/lorem.opf
+++ b/src/test/resources/30/expanded/invalid/encryption-unknown/EPUB/lorem.opf
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="uid">
+    <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+        <dc:identifier id="uid">urn:uuid:550e8400-e29b-41d4-a716-4466674412314</dc:identifier>
+        <dc:title>Lorem Ipsum</dc:title>        
+        <dc:language>la</dc:language>
+        <dc:date>2011-09-01</dc:date>
+        <meta property="dcterms:modified">2011-09-01T17:18:00Z</meta>
+    </metadata> 
+    <manifest>
+        <item id="t1" href="lorem.xhtml" properties="nav" media-type="application/xhtml+xml" />                
+        <item id="css" href="lorem.css" media-type="text/css" />
+    </manifest>
+    <spine>
+        <itemref idref="t1" />        
+    </spine>    
+</package>

--- a/src/test/resources/30/expanded/invalid/encryption-unknown/EPUB/lorem.xhtml
+++ b/src/test/resources/30/expanded/invalid/encryption-unknown/EPUB/lorem.xhtml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+1234

--- a/src/test/resources/30/expanded/invalid/encryption-unknown/META-INF/container.xml
+++ b/src/test/resources/30/expanded/invalid/encryption-unknown/META-INF/container.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container xmlns="urn:oasis:names:tc:opendocument:xmlns:container" version="1.0">
+	<rootfiles>
+		<rootfile full-path="EPUB/lorem.opf" 	
+			media-type="application/oebps-package+xml"/>
+	</rootfiles>
+</container>

--- a/src/test/resources/30/expanded/invalid/encryption-unknown/META-INF/encryption.xml
+++ b/src/test/resources/30/expanded/invalid/encryption-unknown/META-INF/encryption.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<encryption
+    xmlns ="urn:oasis:names:tc:opendocument:xmlns:container"
+    xmlns:enc="http://www.w3.org/2001/04/xmlenc#"
+    xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+    <enc:EncryptedKey Id="EK">
+        <enc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5"/>
+        <ds:KeyInfo>
+            <ds:KeyName>John Smith</ds:KeyName>
+        </ds:KeyInfo>
+        <enc:CipherData>
+            <enc:CipherValue>Sm9obiBTbWl0aA==</enc:CipherValue>
+        </enc:CipherData>
+    </enc:EncryptedKey>
+    <enc:EncryptedData Id="ED1">
+        <enc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#kw-aes128"/>
+        <ds:KeyInfo>
+            <ds:RetrievalMethod URI="#EK"
+                Type="http://www.w3.org/2001/04/xmlenc#EncryptedKey"/>
+        </ds:KeyInfo>
+        <enc:CipherData>
+            <enc:CipherReference URI="EPUB/lorem.xhtml"/>
+        </enc:CipherData>
+    </enc:EncryptedData>
+</encryption>

--- a/src/test/resources/30/expanded/invalid/encryption-unknown/mimetype
+++ b/src/test/resources/30/expanded/invalid/encryption-unknown/mimetype
@@ -1,0 +1,1 @@
+application/epub+zip    


### PR DESCRIPTION
The XML parsers triggered in the `ctc` package were sometimes
reporting PKG-008 (on IOException) or RSC-005 (on SAXException).
These were duplicates, such parsing errors are caught earlier (if
they're not, it's a bug).

Also added a simple test case for an encrypted EPUB with unknown
encryption algorithm.

Fixes #593.