### PR TITLE
Fix tokenization of sets of space-separated tokens in Schematron

### DIFF
--- a/src/main/resources/com/adobe/epubcheck/schema/30/epub-xhtml-30.sch
+++ b/src/main/resources/com/adobe/epubcheck/schema/30/epub-xhtml-30.sch
@@ -231,7 +231,7 @@
         <rule context="h:*[@headers]">
             <let name="table" value="ancestor::h:table"/>
             <assert
-                test="every $idref in tokenize(@headers, '\s+') satisfies (some $elem in $table//h:th satisfies ($elem/@id eq $idref))"
+                test="every $idref in tokenize(normalize-space(@headers), '\s+') satisfies (some $elem in $table//h:th satisfies ($elem/@id eq $idref))"
                 >The headers attribute must refer to th elements in the same table.</assert>
         </rule>
     </pattern>
@@ -374,7 +374,7 @@
     <pattern abstract="true" id="idrefs-any">
         <rule context="$element[@$idrefs-attr-name]">
             <assert
-                test="every $idref in tokenize(@$idrefs-attr-name,'\s+') satisfies (some $elem in $id-set satisfies ($elem/@id eq $idref))"
+                test="every $idref in tokenize(normalize-space(@$idrefs-attr-name),'\s+') satisfies (some $elem in $id-set satisfies ($elem/@id eq $idref))"
                 >The <name path="@$idrefs-attr-name"/> attribute must refer to elements in the same
                 document (target ID missing)</assert>
         </rule>

--- a/src/test/resources/30/single/xhtml/valid/tables-001.xhtml
+++ b/src/test/resources/30/single/xhtml/valid/tables-001.xhtml
@@ -109,6 +109,18 @@
                 </tr>
             </tbody>
         </table>
-            
+        <table>
+            <thead>
+                <tr>
+                    <th id="d3350e31">dasd</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td headers="d3350e31 ">2</td>
+                </tr>
+            </tbody>
+        </table>
+
     </body>
 </html>


### PR DESCRIPTION
The HTML specification says:

> A string containing a set of space-separated tokens may have leading
 or trailing space characters.

This commit normalizes whitespace of attributes for which every token
is checked (like "unordered set of unique space-separated tokens"
aka IDREFS).

Fixes #622.