### PR TITLE
add Archive.createArchive(File) method

### DIFF
--- a/src/main/java/com/adobe/epubcheck/util/Archive.java
+++ b/src/main/java/com/adobe/epubcheck/util/Archive.java
@@ -66,6 +66,12 @@ public class Archive
     }
   }
 
+  public void createArchive(File absoluteEpubFilePath)
+  {
+	  this.epubFile = absoluteEpubFilePath;
+	  createArchive();
+  }
+
   public void createArchive()
   {
     // using commons compress to allow setting filename encoding pre java7


### PR DESCRIPTION
When using EpubCheck in projects I often use the `Archive` class to zip up an extracted epub folder.
However, until now, there has been no possibility to specify the output path for the `Archive.createArchive()` method.
This sometimes results in overridden epub files when you extract an existing epub file in the same folder and then check the extracted folder with EpubCheck. Not good.

With this PR I add a new overloaded method `createArchive(File absoluteEpubFilePath)` to change the output destination for the ZIP file.

This affects no existing functionality so I'm sure, we can merge this for the next release, right @rdeltour ?