### PR TITLE
[Build] Require Maven 3.0 and update build dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ EpubCheck is made available under the terms of the [New BSD License](http://open
 
 ## Building EpubCheck
 
-To build epubcheck from the sources you need Java Development Kit (JDK) 1.7 or above and [Apache Maven](http://maven.apache.org/) 2.3 or above installed.
+To build epubcheck from the sources you need Java Development Kit (JDK) 1.7 or above and [Apache Maven](http://maven.apache.org/) 3.0 or above installed.
 On Windows, you should build in a git bash shell (see http://github.com help)
 
 You will also need Python to be able to run the BookReporter and related tools.

--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,10 @@
         <tool.build.date>${maven.build.timestamp}</tool.build.date>
     </properties>
 
+	<prerequisites>
+		<maven>3.0</maven>
+	</prerequisites>
+
     <dependencies>
         <dependency>
             <groupId>net.sf.saxon</groupId>
@@ -249,7 +253,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>2.6</version>
+                <version>3.0.1</version>
                 <executions>
                     <execution>
                         <id>copy</id>
@@ -268,7 +272,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
+                <version>3.6.1</version>
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
@@ -297,7 +301,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.12.4</version>
+                <version>2.20</version>
                 <configuration>
                     <argLine>-Xmx1g -Duser.language=en</argLine>
                     <workingDirectory>${project.build.directory}/test-classes</workingDirectory>
@@ -339,7 +343,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>xml-maven-plugin</artifactId>
-                <version>1.0</version>
+                <version>1.0.1</version>
                 <executions>
                     <execution>
                         <goals>
@@ -379,7 +383,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>license-maven-plugin</artifactId>
-                <version>1.3</version>
+                <version>1.12</version>
                 <executions>
                     <execution>
                         <id>thirdparty-licenses</id>
@@ -399,7 +403,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.4</version>
+                <version>3.0.2</version>
                 <configuration>
                     <finalName>${project.artifactId}</finalName>
                     <archive>
@@ -433,7 +437,7 @@
                 <!-- https://jira.codehaus.org/browse/SCM-738 -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.4.2</version>
+                <version>2.5.3</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.apache.maven.scm</groupId>
@@ -448,7 +452,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.3</version>
+                <version>3.0.0</version>
                 <executions>
                     <execution>
                         <id>dist-assembly</id>

--- a/pom.xml
+++ b/pom.xml
@@ -253,7 +253,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.0.2</version>
                 <executions>
                     <execution>
                         <id>copy</id>
@@ -272,7 +272,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.6.1</version>
+                <version>3.7.0</version>
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
@@ -281,7 +281,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>2.3.7</version>
+                <version>2.5.4</version>
                 <extensions>true</extensions>
                 <executions>
                     <execution>
@@ -301,7 +301,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.20</version>
+                <version>2.20.1</version>
                 <configuration>
                     <argLine>-Xmx1g -Duser.language=en</argLine>
                     <workingDirectory>${project.build.directory}/test-classes</workingDirectory>
@@ -383,7 +383,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>license-maven-plugin</artifactId>
-                <version>1.12</version>
+                <version>1.14</version>
                 <executions>
                     <execution>
                         <id>thirdparty-licenses</id>
@@ -452,7 +452,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>dist-assembly</id>


### PR DESCRIPTION
* Require minimum maven version in `pom.xml` as described in `README.md`
* Upgraded maven build plugins as suggested by `mvn versions:display-plugin-updates`