### PR TITLE
[fix #663] Update the OPF20 RNG schema partially to validate empty guide elements

### DIFF
--- a/src/main/resources/com/adobe/epubcheck/schema/20/rng/opf20.rng
+++ b/src/main/resources/com/adobe/epubcheck/schema/20/rng/opf20.rng
@@ -458,9 +458,9 @@ Authors:
 </define>
 
 <define name="OPF20.guide-content">
-  <zeroOrMore>
+  <oneOrMore>
     <ref name="OPF20.reference-element"/>
-  </zeroOrMore>
+  </oneOrMore>
 </define>
 
 <define name="OPF20.reference-element">

--- a/src/test/java/com/adobe/epubcheck/opf/OPFCheckerTest.java
+++ b/src/test/java/com/adobe/epubcheck/opf/OPFCheckerTest.java
@@ -516,6 +516,13 @@ public class OPFCheckerTest
   }
 
   @Test
+  public void testEmptyGuideElementIssue663_EPUB2()
+  {
+    Collections.addAll(expectedErrors, MessageId.RSC_005);
+    testValidateDocument("invalid/issue663_empty-guide.opf", EPUBVersion.VERSION_2);
+  }
+
+  @Test
   public void testFilenameInManifestContainsSpacesIssue239_EPUB2()
   {
     Collections.addAll(expectedWarnings, MessageId.PKG_010);

--- a/src/test/resources/20/single/opf/invalid/issue663_empty-guide.opf
+++ b/src/test/resources/20/single/opf/invalid/issue663_empty-guide.opf
@@ -1,0 +1,29 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<package xmlns:opf="http://www.idpf.org/2007/opf" xmlns:dcterms="http://purl.org/dc/terms/"
+	xmlns:dc="http://purl.org/dc/elements/1.1/"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.idpf.org/2007/opf"
+	version="2.0" unique-identifier="id">
+	<metadata>
+		<dc:rights>Public domain in the USA.</dc:rights>
+		<dc:identifier id="id" opf:scheme="URI"
+			>http://www.gutenberg.org/ebooks/36582</dc:identifier>
+		<dc:creator opf:file-as="Anonymous">Anonymous</dc:creator>
+		<dc:title>Advice to Sunday School Children</dc:title>
+		<dc:language xsi:type="dcterms:RFC4646">en</dc:language>
+		<dc:date opf:event="publication">2011-07-02</dc:date>
+		<dc:date opf:event="conversion">2011-07-03T19:26:31.417584+00:00</dc:date>
+		<dc:source>http://www.gutenberg.org/files/36582/36582-h/36582-h.htm</dc:source>
+		<meta content="item1" name="cover"/>
+	</metadata>
+	<manifest>
+		<item id="Html-cover-page" href="xhtml/cover.xml" media-type="application/xhtml+xml"/>
+		<item id="Cover-image" href="images/...jpg" media-type="image/jpeg"/>
+		<item id="Contents" href="xhtml/contents.html" media-type="application/xhtml+xml"/>
+		<item id="ncx" href="nav.ncx" media-type="application/x-dtbncx+xml"/>
+	</manifest>
+	<spine toc="ncx">
+		<itemref idref="Html-cover-page" linear="no"/>
+		<itemref idref="Contents" linear="yes"/>
+	</spine>
+	<guide/>
+</package>


### PR DESCRIPTION
fixes #663 

This change is in sync with the official OPF schema at http://www.idpf.org/epub/20/spec/OPF_2.0_latest.htm#AppendixA

A test has been added.