### PR TITLE
Update OPF 2.0 RNG schema partially to latest version (changing datatype text to anyURI for href attributes)

### DIFF
--- a/src/main/resources/com/adobe/epubcheck/schema/20/rng/opf20.rng
+++ b/src/main/resources/com/adobe/epubcheck/schema/20/rng/opf20.rng
@@ -18,11 +18,6 @@ Authors:
          Peter Sorotokin <psorotok@adobe.com>
 -->
 
-<!-- must not be present for EpubCheck validation. -->
-<!--<start>
-  <ref name="OPF20.package-element"/>
-</start>-->
-
 <define name="OPF20.optional-id-attribute">
   <optional>
     <attribute name="id">
@@ -71,6 +66,13 @@ Authors:
   </optional>
 </define>
 
+<define name="OPF20.optional-xsi-type">
+  <optional>
+    <attribute name="type" ns="http://www.w3.org/2001/XMLSchema-instance">
+      <text/>
+    </attribute>
+  </optional>
+</define>
 
 <define name="OPF20.package-element">
   <element name="package">
@@ -166,9 +168,12 @@ Authors:
       <data type="ID"/>
     </attribute>
     </optional>
-
+    <ref name="OPF20.optional-xsi-type"/>
     <ref name="OPF20.optional-scheme-attribute"/>
-    <ref name="DC.metadata-common-content"/>
+    <!-- <ref name="DC.metadata-common-content"/>
+    MG 20111024, see epubcheck Issue 114
+    -->
+    <ref name="DC.metadata-required-content"/>    
   </element>
 </define>
 
@@ -183,7 +188,7 @@ Authors:
 <define name="DC.language-element" ns="http://purl.org/dc/elements/1.1/">
   <element name="language">
     <ref name="OPF20.optional-id-attribute"/>
-
+    <ref name="OPF20.optional-xsi-type"/>
     <ref name="DC.metadata-common-content"/>
   </element>
 </define>
@@ -211,7 +216,7 @@ Authors:
     </element>
     <element name="date">
       <ref name="OPF20.optional-id-attribute"/>
-
+      <ref name="OPF20.optional-xsi-type"/>
       <ref name="OPF20.optional-event-attribute"/>
       <ref name="DC.metadata-common-content"/>
     </element>
@@ -222,7 +227,7 @@ Authors:
     </element>
     <element name="format">
       <ref name="OPF20.optional-id-attribute"/>
-
+      <ref name="OPF20.optional-xsi-type"/>
       <ref name="DC.metadata-common-content"/>
     </element>
     <element name="publisher">
@@ -252,7 +257,7 @@ Authors:
     </element>
     <element name="type">
       <ref name="OPF20.optional-id-attribute"/>
-
+      <ref name="OPF20.optional-xsi-type"/>
       <ref name="DC.metadata-common-content"/>
     </element>
   </choice>
@@ -261,6 +266,12 @@ Authors:
 <define name="DC.metadata-common-content">
   <text/>
 </define>
+
+  <define name="DC.metadata-required-content">
+    <data type="token">
+      <param name="minLength">1</param>
+    </data>
+  </define>
 
 <define name="OPF20.x-metadata-element">
   <element name="x-metadata">
@@ -367,7 +378,7 @@ Authors:
 
 <define name="OPF20.spine-content">
   <oneOrMore>
-        <ref name="OPF20.itemref-element"/>
+	<ref name="OPF20.itemref-element"/>
   </oneOrMore>
 </define>
 
@@ -418,7 +429,7 @@ Authors:
 
 <define name="OPF20.tour-content">
   <oneOrMore>
-        <ref name="OPF20.site-element"/>
+	<ref name="OPF20.site-element"/>
   </oneOrMore>
 </define>
 
@@ -479,6 +490,7 @@ Authors:
     <anyName>
       <except>
         <nsName ns="http://www.idpf.org/2007/opf"/>
+        <nsName ns="http://openebook.org/namespaces/oeb-package/1.0/"/>
         <nsName ns="http://purl.org/dc/elements/1.1/"/>
       </except>
     </anyName>

--- a/src/main/resources/com/adobe/epubcheck/schema/20/rng/opf20.rng
+++ b/src/main/resources/com/adobe/epubcheck/schema/20/rng/opf20.rng
@@ -18,6 +18,11 @@ Authors:
          Peter Sorotokin <psorotok@adobe.com>
 -->
 
+<!-- must not be present for EpubCheck validation. -->
+<!--<start>
+  <ref name="OPF20.package-element"/>
+</start>-->
+
 <define name="OPF20.optional-id-attribute">
   <optional>
     <attribute name="id">
@@ -66,13 +71,6 @@ Authors:
   </optional>
 </define>
 
-<define name="OPF20.optional-xsi-type">
-  <optional>
-    <attribute name="type" ns="http://www.w3.org/2001/XMLSchema-instance">
-      <text/>
-    </attribute>
-  </optional>
-</define>
 
 <define name="OPF20.package-element">
   <element name="package">
@@ -168,12 +166,9 @@ Authors:
       <data type="ID"/>
     </attribute>
     </optional>
-    <ref name="OPF20.optional-xsi-type"/>
+
     <ref name="OPF20.optional-scheme-attribute"/>
-    <!-- <ref name="DC.metadata-common-content"/>
-    MG 20111024, see epubcheck Issue 114
-    -->
-    <ref name="DC.metadata-required-content"/>    
+    <ref name="DC.metadata-common-content"/>
   </element>
 </define>
 
@@ -188,7 +183,7 @@ Authors:
 <define name="DC.language-element" ns="http://purl.org/dc/elements/1.1/">
   <element name="language">
     <ref name="OPF20.optional-id-attribute"/>
-    <ref name="OPF20.optional-xsi-type"/>
+
     <ref name="DC.metadata-common-content"/>
   </element>
 </define>
@@ -216,7 +211,7 @@ Authors:
     </element>
     <element name="date">
       <ref name="OPF20.optional-id-attribute"/>
-      <ref name="OPF20.optional-xsi-type"/>
+
       <ref name="OPF20.optional-event-attribute"/>
       <ref name="DC.metadata-common-content"/>
     </element>
@@ -227,7 +222,7 @@ Authors:
     </element>
     <element name="format">
       <ref name="OPF20.optional-id-attribute"/>
-      <ref name="OPF20.optional-xsi-type"/>
+
       <ref name="DC.metadata-common-content"/>
     </element>
     <element name="publisher">
@@ -257,7 +252,7 @@ Authors:
     </element>
     <element name="type">
       <ref name="OPF20.optional-id-attribute"/>
-      <ref name="OPF20.optional-xsi-type"/>
+
       <ref name="DC.metadata-common-content"/>
     </element>
   </choice>
@@ -266,12 +261,6 @@ Authors:
 <define name="DC.metadata-common-content">
   <text/>
 </define>
-
-  <define name="DC.metadata-required-content">
-    <data type="token">
-      <param name="minLength">1</param>
-    </data>
-  </define>
 
 <define name="OPF20.x-metadata-element">
   <element name="x-metadata">
@@ -333,7 +322,7 @@ Authors:
       <data type="ID"/>
     </attribute>
     <attribute name="href">
-      <text/>
+      <data type="anyURI"/>
     </attribute>
     <attribute name="media-type">
       <text/>
@@ -378,7 +367,7 @@ Authors:
 
 <define name="OPF20.spine-content">
   <oneOrMore>
-	<ref name="OPF20.itemref-element"/>
+        <ref name="OPF20.itemref-element"/>
   </oneOrMore>
 </define>
 
@@ -429,7 +418,7 @@ Authors:
 
 <define name="OPF20.tour-content">
   <oneOrMore>
-	<ref name="OPF20.site-element"/>
+        <ref name="OPF20.site-element"/>
   </oneOrMore>
 </define>
 
@@ -440,7 +429,7 @@ Authors:
       <text/>
     </attribute>
     <attribute name="href">
-      <text/>
+      <data type="anyURI"/>
     </attribute>
     <ref name="OPF20.site-content"/>
   </element>
@@ -475,7 +464,7 @@ Authors:
     </attribute>
     </optional>
     <attribute name="href">
-      <text/>
+      <data type="anyURI"/>
     </attribute>
     <ref name="OPF20.reference-content"/>
   </element>
@@ -490,7 +479,6 @@ Authors:
     <anyName>
       <except>
         <nsName ns="http://www.idpf.org/2007/opf"/>
-        <nsName ns="http://openebook.org/namespaces/oeb-package/1.0/"/>
         <nsName ns="http://purl.org/dc/elements/1.1/"/>
       </except>
     </anyName>


### PR DESCRIPTION
When working on #663 and #724 I came across the fact, that the OPF RNG schema in EpubCheck is not up to date.

Schema from http://www.idpf.org/epub/20/spec/OPF_2.0_latest.htm#AppendixA differs in several places from the EpubCheck schema in `src/main/resources/com/adobe/epubcheck/schema/20/rng/opf20.rng`.

I'm not familiar with the process of updating official schemas in the EpubCheck project, so how are the analogues DTDs handled? Where do they come from?

Also: it seems for EpubCheck the RNG `<start>` element must not be present in order to be able to run the checker... right?

Note: the initial commit on this PR breaks the build. The OPF 2.0 schema update obviously has side-effects on the tests which needs to be handled... How?
IMHO, this may also be a reason to make the next release version 4.1.0 and not 4.0.3...