### PR TITLE
[fix #568] Added SMIL schematron check to report when @clipBegin==@clipEnd

### DIFF
--- a/src/main/resources/com/adobe/epubcheck/schema/30/media-overlay-30.sch
+++ b/src/main/resources/com/adobe/epubcheck/schema/30/media-overlay-30.sch
@@ -1,9 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns="http://purl.oclc.org/dsdl/schematron">
-          
-    <ns uri="http://www.idpf.org/2007/ops" prefix="epub"/>
-    <ns uri="http://www.w3.org/ns/SMIL" prefix="s"/>
-          
-    <include href="./mod/id-unique.sch"/>     
-            
+
+	<ns uri="http://www.idpf.org/2007/ops" prefix="epub"/>
+	<ns uri="http://www.w3.org/ns/SMIL" prefix="s"/>
+
+	<include href="./mod/id-unique.sch"/>
+
+	<pattern id="clip-attribute-checks">
+		<rule context="s:audio[@clipBegin and @clipEnd]">
+			<!-- #568 check @clipBegin==@clipEnd -->
+			<assert test="@clipBegin != @clipEnd">Attributes 'clipBegin' and 'clipEnd' must not be equal!</assert>
+		</rule>
+	</pattern>
+
 </schema>

--- a/src/test/java/com/adobe/epubcheck/overlay/OverlayCheckerTest.java
+++ b/src/test/java/com/adobe/epubcheck/overlay/OverlayCheckerTest.java
@@ -165,4 +165,11 @@ public class OverlayCheckerTest
   {
     testValidateDocument("valid/overlay-007.smil");
   }
+
+  @Test
+  public void testValidateDocumentInvalidOverlay008_Issue568()
+  {
+    Collections.addAll(expectedErrors, MessageId.RSC_005);
+    testValidateDocument("invalid/overlay-008.smil");
+  }
 }

--- a/src/test/resources/30/single/overlays/invalid/overlay-008.smil
+++ b/src/test/resources/30/single/overlays/invalid/overlay-008.smil
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?oxygen RNGSchema="../../../src/schema/media-overlay-30.rnc" type="compact"?>
+<?oxygen SCHSchema="../../../src/schema/media-overlay-30.sch"?>
+<smil xmlns="http://www.w3.org/ns/SMIL" version="3.0" xmlns:epub="http://www.idpf.org/2007/ops">
+	<body>
+		<seq id="id1" epub:textref="chapter1.xhtml#sectionstart" epub:type="chapter">
+			<par id="id2">
+				<text src="chapter1.xhtml#text1"/>
+				<audio src="chapter1_audio.mp3" clipBegin="0:23:34.221" clipEnd="0:23:34.221"/>
+			</par>
+		</seq>
+	</body>
+</smil>


### PR DESCRIPTION
This is an attempt to fix #568.

However, this is only a very very basic check which just compares the two attributes and doesn't check for same timestamps in different syntaxes.

Please see issue #568 for ongoing discussion on this topic...