### PR TITLE
Add better url checks

### DIFF
--- a/src/main/java/com/adobe/epubcheck/messages/MessageDictionary.java
+++ b/src/main/java/com/adobe/epubcheck/messages/MessageDictionary.java
@@ -329,6 +329,7 @@ public class MessageDictionary
       map.put(MessageId.RSC_020, Severity.ERROR);
       map.put(MessageId.RSC_021, Severity.ERROR);
       map.put(MessageId.RSC_022, Severity.INFO);
+      map.put(MessageId.RSC_023, Severity.WARNING);
 
       // Scripting
       map.put(MessageId.SCP_001, Severity.USAGE);

--- a/src/main/java/com/adobe/epubcheck/messages/MessageId.java
+++ b/src/main/java/com/adobe/epubcheck/messages/MessageId.java
@@ -292,6 +292,7 @@ public enum MessageId implements Comparable<MessageId>
   RSC_020("RSC-020"),
   RSC_021("RSC-021"),
   RSC_022("RSC-022"),
+  RSC_023("RSC-023"),
 
   // Messages relating to scripting
   SCP_001("SCP-001"),

--- a/src/main/java/com/adobe/epubcheck/ops/OPSHandler.java
+++ b/src/main/java/com/adobe/epubcheck/ops/OPSHandler.java
@@ -224,7 +224,7 @@ public class OPSHandler implements XMLHandler
     URI uri = checkURI(href);
     if (uri == null) return;
 
-    if ("http".equals(uri.getScheme()))
+    if ("http".equals(uri.getScheme()) || "https".equals(uri.getScheme()))
     {
       report.info(path, FeatureEnum.REFERENCE, href);
     }

--- a/src/main/java/com/adobe/epubcheck/ops/OPSHandler.java
+++ b/src/main/java/com/adobe/epubcheck/ops/OPSHandler.java
@@ -235,7 +235,8 @@ public class OPSHandler implements XMLHandler
        */
       if (uri.getHost() == null)
       {
-        report.message(MessageId.RSC_023, parser.getLocation(), uri);
+        int missingSlashes = uri.getSchemeSpecificPart().startsWith("/") ? 1 : 2;
+        report.message(MessageId.RSC_023, parser.getLocation(), uri, missingSlashes, uri.getScheme());
       }
     }
 

--- a/src/main/java/com/adobe/epubcheck/ops/OPSHandler.java
+++ b/src/main/java/com/adobe/epubcheck/ops/OPSHandler.java
@@ -227,6 +227,16 @@ public class OPSHandler implements XMLHandler
     if ("http".equals(uri.getScheme()) || "https".equals(uri.getScheme()))
     {
       report.info(path, FeatureEnum.REFERENCE, href);
+
+      /*
+       * #708 report invalid HTTP/HTTPS URLs
+       * uri.scheme may be correct, but missing a : or a / from the //
+       * leads to uri.getHost() == null
+       */
+      if (uri.getHost() == null)
+      {
+        report.message(MessageId.RSC_023, parser.getLocation(), uri);
+      }
     }
 
     /*

--- a/src/main/resources/com/adobe/epubcheck/messages/MessageBundle.properties
+++ b/src/main/resources/com/adobe/epubcheck/messages/MessageBundle.properties
@@ -293,6 +293,7 @@ RSC_019=EPUBs with Multiple Renditions should contain a META-INF/metadata.xml fi
 RSC_020='%1$s' is not a valid URI.
 RSC_021=A Search Key Map Document must point to Content Documents ('%1$s' was not found in the spine).
 RSC_022=Cannot check image details (requires Java version 7 or higher).
+RSC_023='%1$s' is not a valid URL.
 
 #Scripting
 SCP_001=Use of Javascript eval() function in EPUB scripts is a security risk.

--- a/src/main/resources/com/adobe/epubcheck/messages/MessageBundle.properties
+++ b/src/main/resources/com/adobe/epubcheck/messages/MessageBundle.properties
@@ -293,7 +293,7 @@ RSC_019=EPUBs with Multiple Renditions should contain a META-INF/metadata.xml fi
 RSC_020='%1$s' is not a valid URI.
 RSC_021=A Search Key Map Document must point to Content Documents ('%1$s' was not found in the spine).
 RSC_022=Cannot check image details (requires Java version 7 or higher).
-RSC_023='%1$s' is not a valid URL.
+RSC_023=The URL '%1$s' is missing %2$d slash(es) '/' after the protocol '%3$s:'
 
 #Scripting
 SCP_001=Use of Javascript eval() function in EPUB scripts is a security risk.

--- a/src/test/java/com/adobe/epubcheck/ops/OPSCheckerTest.java
+++ b/src/test/java/com/adobe/epubcheck/ops/OPSCheckerTest.java
@@ -215,6 +215,15 @@ public class OPSCheckerTest
   }
 
   @Test
+  public void testValidateXHTMLUrlChecksInvalid()
+  {
+    Collections.addAll(expectedErrors, MessageId.RSC_020);
+    Collections.addAll(expectedWarnings, MessageId.HTM_025, MessageId.RSC_023, MessageId.RSC_023);
+    testValidateDocument("xhtml/invalid/url-checks_issue-708.xhtml", "application/xhtml+xml",
+        EPUBVersion.VERSION_3);
+  }
+
+  @Test
   public void testValidateXHTMLXml11()
   {
     Collections.addAll(expectedErrors, MessageId.HTM_001);

--- a/src/test/resources/30/single/xhtml/invalid/url-checks_issue-708.xhtml
+++ b/src/test/resources/30/single/xhtml/invalid/url-checks_issue-708.xhtml
@@ -7,8 +7,8 @@
 		<p>
 			<a href="https://www.youtube .com/watch?v=xxxxxxxxxxx">Invalid URI (RSC-020)</a>
 			<a href="httpf://www.youtube.com/watch?v=xxxxxxxxxxx">Unsupported URI scheme (HTM-025)</a>
-			<a href="https:/www.youtube.com/watch?v=xxxxxxxxxxx">Invalid URL (RSC-023)</a>
-			<a href="https:www.youtube.com/watch?v=xxxxxxxxxxx">Invalid URL (RSC-023)</a>
+			<a href="https:/www.youtube.com/watch?v=xxxxxxxxxxx">URL is missing slashes after protocol (RSC-023)</a>
+			<a href="https:www.youtube.com/watch?v=xxxxxxxxxxx">URL is missing slashes after protocol (RSC-023)</a>
 
 			<a href="https://www.youtube.com/watch?v=xxxxxxxxxxx">Valid URI</a>
 			<a href="https://youtube.com/watch?v=xxxxxxxxxxx">Valid URI</a>

--- a/src/test/resources/30/single/xhtml/invalid/url-checks_issue-708.xhtml
+++ b/src/test/resources/30/single/xhtml/invalid/url-checks_issue-708.xhtml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?oxygen RNGSchema="../../../src/schema/epub-xhtml-30.rnc" type="compact"?>
+<?oxygen SCHSchema="../../../src/schema/epub-xhtml-30.sch"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+	<head/>
+	<body>
+		<p>
+			<a href="https://www.youtube .com/watch?v=xxxxxxxxxxx">Invalid URI (RSC-020)</a>
+			<a href="httpf://www.youtube.com/watch?v=xxxxxxxxxxx">Unsupported URI scheme (HTM-025)</a>
+			<a href="https:/www.youtube.com/watch?v=xxxxxxxxxxx">Invalid URL (RSC-023)</a>
+			<a href="https:www.youtube.com/watch?v=xxxxxxxxxxx">Invalid URL (RSC-023)</a>
+
+			<a href="https://www.youtube.com/watch?v=xxxxxxxxxxx">Valid URI</a>
+			<a href="https://youtube.com/watch?v=xxxxxxxxxxx">Valid URI</a>
+			<a href="https://youtube.com/watch?v=xxxxxx%20xxxx">Valid URI</a>
+		</p>
+	</body>
+</html>


### PR DESCRIPTION
Add new Warning(RSC-023) when host of HTTP-URL is null (fixes #708).

Catches URL typos like `https:/www` or `https:www`

----

Plus: also report HTTPS URLs in the list of references (c3c9204)