### PR TITLE
[fix #665] Set -Djava.awt.headless=true in EpubChecker class

### DIFF
--- a/src/main/java/com/adobe/epubcheck/tool/EpubChecker.java
+++ b/src/main/java/com/adobe/epubcheck/tool/EpubChecker.java
@@ -62,6 +62,13 @@ import com.adobe.epubcheck.util.outWriter;
 public class EpubChecker
 {
 
+  static {
+    /* fix #665 (window-less "Checker" gui app on Mac)
+     * set -Djava.awt.headless=true programmatically as early as possible
+     */
+    System.setProperty("java.awt.headless", "true");
+  }
+
   String path = null;
   String mode = null;
   EPUBProfile profile = null;


### PR DESCRIPTION
Set `-Djava.awt.headless=true` in `EpubChecker` class to fix #665 (_GUI focus stolen due to epubcheck launching window-less “Checker” empty GUI app_)

Needs to be set as early as possible in a static way.