### PR TITLE
[fix #457 #734] ACC-008 landmarks issues

### DIFF
--- a/src/main/java/com/adobe/epubcheck/ctc/EpubHTML5StructureCheck.java
+++ b/src/main/java/com/adobe/epubcheck/ctc/EpubHTML5StructureCheck.java
@@ -1,6 +1,5 @@
 package com.adobe.epubcheck.ctc;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Hashtable;
@@ -52,7 +51,6 @@ public class EpubHTML5StructureCheck implements DocumentValidator
   {
     boolean result = false;
     SearchDictionary vtsd = new SearchDictionary(DictionaryType.VALID_TEXT_MEDIA_TYPES);
-    int landmarkNavCount = 0;
     boolean isGlobalFixed = EpubPackage.isGlobalFixed(this.epubPackage);
 
     Hashtable<String, SpineItem> spineItems = new Hashtable<String, SpineItem>();
@@ -147,13 +145,7 @@ public class EpubHTML5StructureCheck implements DocumentValidator
             report.info(null, FeatureEnum.HAS_HTML5, "true");
           }
         }
-        landmarkNavCount += sh.getLandmarkNavCount();
       }
-    }
-    if (landmarkNavCount != 1 && epubPackage.getVersion() == EPUBVersion.VERSION_3)
-    {
-      File zipFile = new File(zip.getName());
-      report.message(MessageId.ACC_008, EPUBLocation.create(zipFile.getName()));
     }
 
     return result;

--- a/src/main/java/com/adobe/epubcheck/ctc/EpubNavCheck.java
+++ b/src/main/java/com/adobe/epubcheck/ctc/EpubNavCheck.java
@@ -1,5 +1,6 @@
 package com.adobe.epubcheck.ctc;
 
+import java.io.File;
 import java.util.HashSet;
 import java.util.Vector;
 import java.util.zip.ZipEntry;
@@ -20,6 +21,7 @@ import com.adobe.epubcheck.ctc.epubpackage.PackageSpine;
 import com.adobe.epubcheck.ctc.epubpackage.SpineItem;
 import com.adobe.epubcheck.messages.MessageId;
 import com.adobe.epubcheck.opf.DocumentValidator;
+import com.adobe.epubcheck.util.EPUBVersion;
 import com.adobe.epubcheck.util.EpubConstants;
 import com.adobe.epubcheck.util.FeatureEnum;
 import com.adobe.epubcheck.util.HandlerUtil;
@@ -123,6 +125,8 @@ public class EpubNavCheck implements DocumentValidator
       // no need to report an error here because it was already reported inside of the docParser.
       return false;
     }
+
+    int landmarkNavCount = 0;
     NodeList n = doc.getElementsByTagName("nav");
 
     for (int i = 0; i < n.getLength(); i++)
@@ -160,7 +164,16 @@ public class EpubNavCheck implements DocumentValidator
         {
           report.message(MessageId.NAV_002, EPUBLocation.create(navDocEntry, HandlerUtil.getElementLineNumber(navElement), HandlerUtil.getElementColumnNumber(navElement), "page-list"));
         }
+        else if (type.equals("landmarks"))
+        {
+          ++landmarkNavCount;
+        }
       }
+    }
+
+    if (landmarkNavCount == 0)
+    {
+      report.message(MessageId.ACC_008, EPUBLocation.create(navDocEntry));
     }
 
     PackageManifest manifest = epack.getManifest();

--- a/src/main/java/com/adobe/epubcheck/ctc/xml/HTMLTagsAnalyseHandler.java
+++ b/src/main/java/com/adobe/epubcheck/ctc/xml/HTMLTagsAnalyseHandler.java
@@ -304,7 +304,7 @@ public class HTMLTagsAnalyseHandler extends DefaultHandler
     else if ("nav".compareTo(tagName) == 0)
     {
       String type = attributes.getValue(EpubConstants.EpubTypeNamespaceUri, "type");
-      if (type != null && "landmark".compareToIgnoreCase(type) == 0)
+      if (type != null && "landmarks".compareToIgnoreCase(type) == 0)
       {
         ++landmarkNavCount;
       }

--- a/src/main/java/com/adobe/epubcheck/ctc/xml/HTMLTagsAnalyseHandler.java
+++ b/src/main/java/com/adobe/epubcheck/ctc/xml/HTMLTagsAnalyseHandler.java
@@ -303,7 +303,8 @@ public class HTMLTagsAnalyseHandler extends DefaultHandler
     }
     else if ("nav".compareTo(tagName) == 0)
     {
-      String type = attributes.getValue(EpubConstants.EpubTypeNamespaceUri, "type");
+      String epubPrefix = namespaceHelper.findPrefixForUri(EpubConstants.EpubTypeNamespaceUri);
+      String type = attributes.getValue(epubPrefix+":type");
       if (type != null && "landmarks".compareToIgnoreCase(type) == 0)
       {
         ++landmarkNavCount;

--- a/src/test/resources/com/adobe/epubcheck/test/command_line/failonwarnings_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/command_line/failonwarnings_expected_results.json
@@ -1,11 +1,11 @@
 {
   "customMessageFileName" : null,
   "checker" : {
-    "path" : "./target/test-classes/com/adobe/epubcheck/test/command_line/failonwarnings.epub",
+    "path" : "./com/adobe/epubcheck/test/command_line/failonwarnings.epub",
     "filename" : "failonwarnings.epub",
-    "checkerVersion" : "4.0.0-alpha12-SNAPSHOT",
-    "checkDate" : "03-25-2015 10:06:20",
-    "elapsedTime" : 62,
+    "checkerVersion" : "4.0.3-SNAPSHOT",
+    "checkDate" : "12-31-2016 01:11:58",
+    "elapsedTime" : 58,
     "nFatal" : 0,
     "nError" : 0,
     "nWarning" : 1,
@@ -266,7 +266,7 @@
     "message" : "Navigation Document has no 'landmarks nav' element.",
     "additionalLocations" : 0,
     "locations" : [ {
-      "path" : "failonwarnings.epub",
+      "path" : "OPS/toc.xhtml",
       "line" : -1,
       "column" : -1,
       "context" : null

--- a/src/test/resources/com/adobe/epubcheck/test/command_line/jsonfile_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/command_line/jsonfile_expected_results.json
@@ -1,11 +1,11 @@
 {
   "customMessageFileName" : null,
   "checker" : {
-    "path" : "./target/test-classes/com/adobe/epubcheck/test/command_line/jsonfile.epub",
+    "path" : "./com/adobe/epubcheck/test/command_line/jsonfile.epub",
     "filename" : "jsonfile.epub",
-    "checkerVersion" : "4.0.0-alpha12-SNAPSHOT",
-    "checkDate" : "03-25-2015 10:06:20",
-    "elapsedTime" : 58,
+    "checkerVersion" : "4.0.3-SNAPSHOT",
+    "checkDate" : "12-31-2016 18:59:12",
+    "elapsedTime" : 39,
     "nFatal" : 0,
     "nError" : 0,
     "nWarning" : 0,
@@ -266,7 +266,7 @@
     "message" : "Navigation Document has no 'landmarks nav' element.",
     "additionalLocations" : 0,
     "locations" : [ {
-      "path" : "jsonfile.epub",
+      "path" : "OPS/toc.xhtml",
       "line" : -1,
       "column" : -1,
       "context" : null

--- a/src/test/resources/com/adobe/epubcheck/test/command_line/passonwarnings_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/command_line/passonwarnings_expected_results.json
@@ -1,11 +1,11 @@
 {
   "customMessageFileName" : null,
   "checker" : {
-    "path" : "./target/test-classes/com/adobe/epubcheck/test/command_line/passonwarnings.epub",
+    "path" : "./com/adobe/epubcheck/test/command_line/passonwarnings.epub",
     "filename" : "passonwarnings.epub",
-    "checkerVersion" : "4.0.0-alpha12-SNAPSHOT",
-    "checkDate" : "03-25-2015 10:06:20",
-    "elapsedTime" : 68,
+    "checkerVersion" : "4.0.3-SNAPSHOT",
+    "checkDate" : "12-31-2016 01:11:58",
+    "elapsedTime" : 39,
     "nFatal" : 0,
     "nError" : 0,
     "nWarning" : 0,
@@ -266,7 +266,7 @@
     "message" : "Navigation Document has no 'landmarks nav' element.",
     "additionalLocations" : 0,
     "locations" : [ {
-      "path" : "passonwarnings.epub",
+      "path" : "OPS/toc.xhtml",
       "line" : -1,
       "column" : -1,
       "context" : null

--- a/src/test/resources/com/adobe/epubcheck/test/command_line/severity_overrideBadId_expected_results.txt
+++ b/src/test/resources/com/adobe/epubcheck/test/command_line/severity_overrideBadId_expected_results.txt
@@ -1,5 +1,5 @@
 Start command_line test('severity_overrideBadId')
-ERROR(CHK-002): ./com/adobe/epubcheck/test/command_line/severity/(1,0): Unrecognized custom message id BogusID encountered in message overrides file './com/adobe/epubcheck/test/command_line/severity_overrideBadId.txt'.
+ERROR(CHK-002): ./com/adobe/epubcheck/test/command_line/severity(1,0): Unrecognized custom message id BogusID encountered in message overrides file './com/adobe/epubcheck/test/command_line/severity_overrideBadId.txt'.
 Validating using EPUB version 3.0.1 rules.
 USAGE(ACC-007): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/external_css.xhtml(-1,-1): Content Documents do not use 'epub:type' attributes for semantic inflection.
 ERROR(CSS-001): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(27,13): The 'unicode-bidi' property must not be included in an EPUB Style Sheet.
@@ -12,12 +12,12 @@ USAGE(ACC-007): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/inline
 ERROR(CSS-001): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(55,5): The 'unicode-bidi' property must not be included in an EPUB Style Sheet.
 ERROR(CSS-001): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(56,5): The 'direction' property must not be included in an EPUB Style Sheet.
 WARNING(CSS-006): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(66,5): CSS position:fixed property should not be used in EPUBs.
+USAGE(ACC-008): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/toc.xhtml(-1,-1): Navigation Document has no 'landmarks nav' element.
 USAGE(HTM-010): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/toc.ncx(2,68): Namespace uri 'http://www.daisy.org/z3986/2005/ncx/' was found.
 USAGE(OPF-059): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/toc.ncx(-1,-1): Spine item has no NCX entry reference.
 USAGE(OPF-059): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/toc.ncx(-1,-1): Spine item has no NCX entry reference.
 USAGE(CSS-012): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/external_css.xhtml(6,62): Document links to multiple CSS files.
 USAGE(CSS-012): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/external_css.xhtml(7,66): Document links to multiple CSS files.
-USAGE(ACC-008): ./com/adobe/epubcheck/test/command_line/severity.epub/severity.epub(-1,-1): Navigation Document has no 'landmarks nav' element.
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(2,5): Value of CSS property 'font-size' does not use a relative size.
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(7,5): Value of CSS property 'font-size' does not use a relative size.
 USAGE(ACC-015): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(7,5): Value of CSS property 'line-height' does not use a relative size.
@@ -56,23 +56,23 @@ USAGE(ACC-013): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/inline
 USAGE(ACC-013): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/inline_css.xhtml(11,97): Content file contains at least one inline style declaration.
 USAGE(ACC-013): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/inline_css.xhtml(14,50): Content file contains at least one inline style declaration.
 USAGE(ACC-013): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/inline_css.xhtml(15,41): Content file contains at least one inline style declaration.
-USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(1,1): CSS class Selector is not used.
-USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(22,1): CSS class Selector is not used.
-USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(14,1): CSS class Selector is not used.
+USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(6,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(10,1): CSS class Selector is not used.
+USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(14,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(18,1): CSS class Selector is not used.
+USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(22,1): CSS class Selector is not used.
+USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(30,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(34,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(38,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(42,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(46,1): CSS class Selector is not used.
-USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(30,1): CSS class Selector is not used.
-USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(6,1): CSS class Selector is not used.
-USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(30,1): CSS class Selector is not used.
-USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(56,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(82,1): CSS class Selector is not used.
-USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(49,1): CSS class Selector is not used.
-USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(36,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(98,5): CSS class Selector is not used.
+USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(1,1): CSS class Selector is not used.
+USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(30,1): CSS class Selector is not used.
+USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(36,1): CSS class Selector is not used.
+USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(49,1): CSS class Selector is not used.
+USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(56,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(62,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(66,3): CSS class Selector is not used.
 

--- a/src/test/resources/com/adobe/epubcheck/test/command_line/severity_overrideBadMessage_expected_results.txt
+++ b/src/test/resources/com/adobe/epubcheck/test/command_line/severity_overrideBadMessage_expected_results.txt
@@ -1,6 +1,6 @@
 Start command_line test('severity_overrideBadMessage')
-ERROR(CHK-004): ./com/adobe/epubcheck/test/command_line/severity/(1,0): The custom message contains too many parameters in message overrides file './com/adobe/epubcheck/test/command_line/severity_overrideBadMessage.txt'.
-ERROR(CHK-005): ./com/adobe/epubcheck/test/command_line/severity/(2,0): The custom suggestion contains too many parameters in message overrides file './com/adobe/epubcheck/test/command_line/severity_overrideBadMessage.txt'.
+ERROR(CHK-004): ./com/adobe/epubcheck/test/command_line/severity(1,0): The custom message contains too many parameters in message overrides file './com/adobe/epubcheck/test/command_line/severity_overrideBadMessage.txt'.
+ERROR(CHK-005): ./com/adobe/epubcheck/test/command_line/severity(2,0): The custom suggestion contains too many parameters in message overrides file './com/adobe/epubcheck/test/command_line/severity_overrideBadMessage.txt'.
 Validating using EPUB version 3.0.1 rules.
 USAGE(ACC-007): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/external_css.xhtml(-1,-1): Content Documents do not use 'epub:type' attributes for semantic inflection.
 ERROR(CSS-001): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(27,13): The 'unicode-bidi' property must not be included in an EPUB Style Sheet.
@@ -13,12 +13,12 @@ USAGE(ACC-007): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/inline
 ERROR(CSS-001): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(55,5): The 'unicode-bidi' property must not be included in an EPUB Style Sheet.
 ERROR(CSS-001): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(56,5): The 'direction' property must not be included in an EPUB Style Sheet.
 WARNING(CSS-006): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(66,5): CSS position:fixed property should not be used in EPUBs.
+USAGE(ACC-008): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/toc.xhtml(-1,-1): Navigation Document has no 'landmarks nav' element.
 USAGE(HTM-010): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/toc.ncx(2,68): Namespace uri 'http://www.daisy.org/z3986/2005/ncx/' was found.
 USAGE(OPF-059): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/toc.ncx(-1,-1): Spine item has no NCX entry reference.
 USAGE(OPF-059): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/toc.ncx(-1,-1): Spine item has no NCX entry reference.
 USAGE(CSS-012): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/external_css.xhtml(6,62): Document links to multiple CSS files.
 USAGE(CSS-012): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/external_css.xhtml(7,66): Document links to multiple CSS files.
-USAGE(ACC-008): ./com/adobe/epubcheck/test/command_line/severity.epub/severity.epub(-1,-1): Navigation Document has no 'landmarks nav' element.
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(2,5): Value of CSS property 'font-size' does not use a relative size.
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(7,5): Value of CSS property 'font-size' does not use a relative size.
 USAGE(ACC-015): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(7,5): This is an overridden message.
@@ -57,23 +57,23 @@ USAGE(ACC-013): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/inline
 USAGE(ACC-013): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/inline_css.xhtml(11,97): Content file contains at least one inline style declaration.
 USAGE(ACC-013): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/inline_css.xhtml(14,50): Content file contains at least one inline style declaration.
 USAGE(ACC-013): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/inline_css.xhtml(15,41): Content file contains at least one inline style declaration.
-USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(1,1): CSS class Selector is not used.
-USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(22,1): CSS class Selector is not used.
-USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(14,1): CSS class Selector is not used.
+USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(6,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(10,1): CSS class Selector is not used.
+USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(14,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(18,1): CSS class Selector is not used.
+USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(22,1): CSS class Selector is not used.
+USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(30,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(34,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(38,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(42,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(46,1): CSS class Selector is not used.
-USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(30,1): CSS class Selector is not used.
-USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(6,1): CSS class Selector is not used.
-USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(30,1): CSS class Selector is not used.
-USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(56,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(82,1): CSS class Selector is not used.
-USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(49,1): CSS class Selector is not used.
-USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(36,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(98,5): CSS class Selector is not used.
+USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(1,1): CSS class Selector is not used.
+USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(30,1): CSS class Selector is not used.
+USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(36,1): CSS class Selector is not used.
+USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(49,1): CSS class Selector is not used.
+USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(56,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(62,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(66,3): CSS class Selector is not used.
 

--- a/src/test/resources/com/adobe/epubcheck/test/command_line/severity_overrideBadSeverity_expected_results.txt
+++ b/src/test/resources/com/adobe/epubcheck/test/command_line/severity_overrideBadSeverity_expected_results.txt
@@ -1,5 +1,5 @@
 Start command_line test('severity_overrideBadSeverity')
-ERROR(CHK-003): ./com/adobe/epubcheck/test/command_line/severity/(1,8): Unrecognized custom message severity 'BogusSeverity' encountered in message overrides file './com/adobe/epubcheck/test/command_line/severity_overrideBadSeverity.txt'.
+ERROR(CHK-003): ./com/adobe/epubcheck/test/command_line/severity(1,8): Unrecognized custom message severity 'BogusSeverity' encountered in message overrides file './com/adobe/epubcheck/test/command_line/severity_overrideBadSeverity.txt'.
 Validating using EPUB version 3.0.1 rules.
 USAGE(ACC-007): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/external_css.xhtml(-1,-1): Content Documents do not use 'epub:type' attributes for semantic inflection.
 ERROR(CSS-001): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(27,13): The 'unicode-bidi' property must not be included in an EPUB Style Sheet.
@@ -12,12 +12,12 @@ USAGE(ACC-007): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/inline
 ERROR(CSS-001): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(55,5): The 'unicode-bidi' property must not be included in an EPUB Style Sheet.
 ERROR(CSS-001): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(56,5): The 'direction' property must not be included in an EPUB Style Sheet.
 WARNING(CSS-006): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(66,5): CSS position:fixed property should not be used in EPUBs.
+USAGE(ACC-008): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/toc.xhtml(-1,-1): Navigation Document has no 'landmarks nav' element.
 USAGE(HTM-010): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/toc.ncx(2,68): Namespace uri 'http://www.daisy.org/z3986/2005/ncx/' was found.
 USAGE(OPF-059): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/toc.ncx(-1,-1): Spine item has no NCX entry reference.
 USAGE(OPF-059): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/toc.ncx(-1,-1): Spine item has no NCX entry reference.
 USAGE(CSS-012): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/external_css.xhtml(6,62): Document links to multiple CSS files.
 USAGE(CSS-012): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/external_css.xhtml(7,66): Document links to multiple CSS files.
-USAGE(ACC-008): ./com/adobe/epubcheck/test/command_line/severity.epub/severity.epub(-1,-1): Navigation Document has no 'landmarks nav' element.
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(2,5): Value of CSS property 'font-size' does not use a relative size.
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(7,5): Value of CSS property 'font-size' does not use a relative size.
 USAGE(ACC-015): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(7,5): Value of CSS property 'line-height' does not use a relative size.
@@ -56,23 +56,23 @@ USAGE(ACC-013): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/inline
 USAGE(ACC-013): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/inline_css.xhtml(11,97): Content file contains at least one inline style declaration.
 USAGE(ACC-013): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/inline_css.xhtml(14,50): Content file contains at least one inline style declaration.
 USAGE(ACC-013): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/inline_css.xhtml(15,41): Content file contains at least one inline style declaration.
-USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(1,1): CSS class Selector is not used.
-USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(22,1): CSS class Selector is not used.
-USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(14,1): CSS class Selector is not used.
+USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(6,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(10,1): CSS class Selector is not used.
+USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(14,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(18,1): CSS class Selector is not used.
+USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(22,1): CSS class Selector is not used.
+USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(30,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(34,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(38,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(42,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(46,1): CSS class Selector is not used.
-USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(30,1): CSS class Selector is not used.
-USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(6,1): CSS class Selector is not used.
-USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(30,1): CSS class Selector is not used.
-USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(56,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(82,1): CSS class Selector is not used.
-USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(49,1): CSS class Selector is not used.
-USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(36,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(98,5): CSS class Selector is not used.
+USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(1,1): CSS class Selector is not used.
+USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(30,1): CSS class Selector is not used.
+USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(36,1): CSS class Selector is not used.
+USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(49,1): CSS class Selector is not used.
+USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(56,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(62,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(66,3): CSS class Selector is not used.
 

--- a/src/test/resources/com/adobe/epubcheck/test/command_line/severity_overrideMissingFile_expected_results.txt
+++ b/src/test/resources/com/adobe/epubcheck/test/command_line/severity_overrideMissingFile_expected_results.txt
@@ -12,12 +12,12 @@ USAGE(ACC-007): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/inline
 ERROR(CSS-001): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(55,5): The 'unicode-bidi' property must not be included in an EPUB Style Sheet.
 ERROR(CSS-001): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(56,5): The 'direction' property must not be included in an EPUB Style Sheet.
 WARNING(CSS-006): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(66,5): CSS position:fixed property should not be used in EPUBs.
+USAGE(ACC-008): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/toc.xhtml(-1,-1): Navigation Document has no 'landmarks nav' element.
 USAGE(HTM-010): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/toc.ncx(2,68): Namespace uri 'http://www.daisy.org/z3986/2005/ncx/' was found.
 USAGE(OPF-059): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/toc.ncx(-1,-1): Spine item has no NCX entry reference.
 USAGE(OPF-059): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/toc.ncx(-1,-1): Spine item has no NCX entry reference.
 USAGE(CSS-012): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/external_css.xhtml(6,62): Document links to multiple CSS files.
 USAGE(CSS-012): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/external_css.xhtml(7,66): Document links to multiple CSS files.
-USAGE(ACC-008): ./com/adobe/epubcheck/test/command_line/severity.epub/severity.epub(-1,-1): Navigation Document has no 'landmarks nav' element.
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(2,5): Value of CSS property 'font-size' does not use a relative size.
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(7,5): Value of CSS property 'font-size' does not use a relative size.
 USAGE(ACC-015): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(7,5): Value of CSS property 'line-height' does not use a relative size.
@@ -56,23 +56,23 @@ USAGE(ACC-013): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/inline
 USAGE(ACC-013): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/inline_css.xhtml(11,97): Content file contains at least one inline style declaration.
 USAGE(ACC-013): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/inline_css.xhtml(14,50): Content file contains at least one inline style declaration.
 USAGE(ACC-013): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/inline_css.xhtml(15,41): Content file contains at least one inline style declaration.
-USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(1,1): CSS class Selector is not used.
-USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(22,1): CSS class Selector is not used.
-USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(14,1): CSS class Selector is not used.
+USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(6,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(10,1): CSS class Selector is not used.
+USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(14,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(18,1): CSS class Selector is not used.
+USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(22,1): CSS class Selector is not used.
+USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(30,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(34,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(38,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(42,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(46,1): CSS class Selector is not used.
-USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(30,1): CSS class Selector is not used.
-USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(6,1): CSS class Selector is not used.
-USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(30,1): CSS class Selector is not used.
-USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(56,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(82,1): CSS class Selector is not used.
-USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(49,1): CSS class Selector is not used.
-USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(36,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(98,5): CSS class Selector is not used.
+USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(1,1): CSS class Selector is not used.
+USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(30,1): CSS class Selector is not used.
+USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(36,1): CSS class Selector is not used.
+USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(49,1): CSS class Selector is not used.
+USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(56,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(62,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(66,3): CSS class Selector is not used.
 

--- a/src/test/resources/com/adobe/epubcheck/test/command_line/severity_overrideOk_expected_results.txt
+++ b/src/test/resources/com/adobe/epubcheck/test/command_line/severity_overrideOk_expected_results.txt
@@ -11,12 +11,12 @@ USAGE(ACC-007): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/inline
 ERROR(CSS-001): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(55,5): The 'unicode-bidi' property must not be included in an EPUB Style Sheet.
 ERROR(CSS-001): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(56,5): The 'direction' property must not be included in an EPUB Style Sheet.
 WARNING(CSS-006): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(66,5): CSS position:fixed property should not be used in EPUBs.
+USAGE(ACC-008): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/toc.xhtml(-1,-1): Navigation Document has no 'landmarks nav' element.
 USAGE(HTM-010): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/toc.ncx(2,68): Namespace uri 'http://www.daisy.org/z3986/2005/ncx/' was found.
 USAGE(OPF-059): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/toc.ncx(-1,-1): Spine item has no NCX entry reference.
 USAGE(OPF-059): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/toc.ncx(-1,-1): Spine item has no NCX entry reference.
 ERROR(CSS-012): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/external_css.xhtml(6,62):  (severity overridden from USAGE) This is an overridden message
 ERROR(CSS-012): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/external_css.xhtml(7,66):  (severity overridden from USAGE) This is an overridden message
-USAGE(ACC-008): ./com/adobe/epubcheck/test/command_line/severity.epub/severity.epub(-1,-1): Navigation Document has no 'landmarks nav' element.
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(2,5): Value of CSS property 'font-size' does not use a relative size.
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(7,5): Value of CSS property 'font-size' does not use a relative size.
 USAGE(ACC-015): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(7,5): Value of CSS property 'line-height' does not use a relative size.
@@ -54,23 +54,23 @@ USAGE(ACC-013): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/inline
 USAGE(ACC-013): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/inline_css.xhtml(11,97): Content file contains at least one inline style declaration.
 USAGE(ACC-013): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/inline_css.xhtml(14,50): Content file contains at least one inline style declaration.
 USAGE(ACC-013): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/inline_css.xhtml(15,41): Content file contains at least one inline style declaration.
-USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(1,1): CSS class Selector is not used.
-USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(22,1): CSS class Selector is not used.
-USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(14,1): CSS class Selector is not used.
+USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(6,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(10,1): CSS class Selector is not used.
+USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(14,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(18,1): CSS class Selector is not used.
+USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(22,1): CSS class Selector is not used.
+USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(30,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(34,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(38,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(42,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(46,1): CSS class Selector is not used.
-USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(30,1): CSS class Selector is not used.
-USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(6,1): CSS class Selector is not used.
-USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(30,1): CSS class Selector is not used.
-USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(56,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(82,1): CSS class Selector is not used.
-USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(49,1): CSS class Selector is not used.
-USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(36,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(98,5): CSS class Selector is not used.
+USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(1,1): CSS class Selector is not used.
+USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(30,1): CSS class Selector is not used.
+USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(36,1): CSS class Selector is not used.
+USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(49,1): CSS class Selector is not used.
+USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(56,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(62,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(66,3): CSS class Selector is not used.
 

--- a/src/test/resources/com/adobe/epubcheck/test/command_line/severity_usage_expected_results.txt
+++ b/src/test/resources/com/adobe/epubcheck/test/command_line/severity_usage_expected_results.txt
@@ -11,12 +11,12 @@ USAGE(ACC-007): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/inline
 ERROR(CSS-001): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(55,5): The 'unicode-bidi' property must not be included in an EPUB Style Sheet.
 ERROR(CSS-001): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(56,5): The 'direction' property must not be included in an EPUB Style Sheet.
 WARNING(CSS-006): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(66,5): CSS position:fixed property should not be used in EPUBs.
+USAGE(ACC-008): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/toc.xhtml(-1,-1): Navigation Document has no 'landmarks nav' element.
 USAGE(HTM-010): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/toc.ncx(2,68): Namespace uri 'http://www.daisy.org/z3986/2005/ncx/' was found.
 USAGE(OPF-059): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/toc.ncx(-1,-1): Spine item has no NCX entry reference.
 USAGE(OPF-059): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/toc.ncx(-1,-1): Spine item has no NCX entry reference.
 USAGE(CSS-012): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/external_css.xhtml(6,62): Document links to multiple CSS files.
 USAGE(CSS-012): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/external_css.xhtml(7,66): Document links to multiple CSS files.
-USAGE(ACC-008): ./com/adobe/epubcheck/test/command_line/severity.epub/severity.epub(-1,-1): Navigation Document has no 'landmarks nav' element.
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(2,5): Value of CSS property 'font-size' does not use a relative size.
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(7,5): Value of CSS property 'font-size' does not use a relative size.
 USAGE(ACC-015): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(7,5): Value of CSS property 'line-height' does not use a relative size.
@@ -55,23 +55,23 @@ USAGE(ACC-013): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/inline
 USAGE(ACC-013): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/inline_css.xhtml(11,97): Content file contains at least one inline style declaration.
 USAGE(ACC-013): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/inline_css.xhtml(14,50): Content file contains at least one inline style declaration.
 USAGE(ACC-013): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/inline_css.xhtml(15,41): Content file contains at least one inline style declaration.
-USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(1,1): CSS class Selector is not used.
-USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(22,1): CSS class Selector is not used.
-USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(14,1): CSS class Selector is not used.
+USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(6,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(10,1): CSS class Selector is not used.
+USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(14,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(18,1): CSS class Selector is not used.
+USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(22,1): CSS class Selector is not used.
+USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(30,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(34,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(38,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(42,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(46,1): CSS class Selector is not used.
-USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(30,1): CSS class Selector is not used.
-USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(6,1): CSS class Selector is not used.
-USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(30,1): CSS class Selector is not used.
-USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(56,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(82,1): CSS class Selector is not used.
-USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(49,1): CSS class Selector is not used.
-USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(36,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(98,5): CSS class Selector is not used.
+USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(1,1): CSS class Selector is not used.
+USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(30,1): CSS class Selector is not used.
+USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(36,1): CSS class Selector is not used.
+USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(49,1): CSS class Selector is not used.
+USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(56,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(62,1): CSS class Selector is not used.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(66,3): CSS class Selector is not used.
 

--- a/src/test/resources/com/adobe/epubcheck/test/command_line/xmlfile_expected_results.xml
+++ b/src/test/resources/com/adobe/epubcheck/test/command_line/xmlfile_expected_results.xml
@@ -1,29 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jhove xmlns="http://hul.harvard.edu/ois/xml/ns/jhove" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="epubcheck" release="4.0.0-alpha11-SNAPSHOT" date="2012-10-31">
- <date>2014-09-05T03:27:51+02:00</date>
+<jhove xmlns="http://hul.harvard.edu/ois/xml/ns/jhove"
+       date="2016-12-28"
+       name="epubcheck"
+       release="4.0.3-SNAPSHOT">
+ <date>2016-12-31T01:11:58+01:00</date>
  <repInfo uri="xmlfile.epub">
-  <created>2014-09-05T03:24:40Z</created>
+  <created>2016-12-31T01:11:26Z</created>
   <lastModified>2012-10-10T12:00:00Z</lastModified>
   <format>application/epub+zip</format>
   <version>3.0.1</version>
   <status>Well-formed</status>
   <messages>
+   <message severity="info" subMessage="ACC-007">ACC-007, HINT, [Content Documents do not use 'epub:type' attributes for semantic inflection.], OPS/external_css.xhtml</message>
+   <message severity="info" subMessage="ACC-007">ACC-007, HINT, [Content Documents do not use 'epub:type' attributes for semantic inflection.], OPS/style_tag_css.xhtml</message>
+   <message severity="info" subMessage="ACC-007">ACC-007, HINT, [Content Documents do not use 'epub:type' attributes for semantic inflection.], OPS/inline_css.xhtml</message>
+   <message severity="info" subMessage="ACC-008">ACC-008, HINT, [Navigation Document has no 'landmarks nav' element.], OPS/toc.xhtml</message>
    <message severity="info" subMessage="HTM-010">HTM-010, HINT, [Namespace uri 'http://www.daisy.org/z3986/2005/ncx/' was found.], OPS/toc.ncx (2-68)</message>
    <message severity="info" subMessage="OPF-059">OPF-059, HINT, [Spine item has no NCX entry reference.], OPS/toc.ncx</message>
    <message severity="info" subMessage="OPF-059">OPF-059, HINT, [Spine item has no NCX entry reference.], OPS/toc.ncx</message>
-   <message severity="info" subMessage="ACC-008">ACC-008, HINT, [Navigation Document has no 'landmarks nav' element.], xmlfile.epub</message>
    <message severity="info" subMessage="CSS-009">CSS-009, HINT, [Use of certain CSS such as Columns, Transforms, Transitions, box-sizing or KeyFrames can cause pagination issues.], OPS/style.css (3-23)</message>
    <message severity="info" subMessage="CSS-009">CSS-009, HINT, [Use of certain CSS such as Columns, Transforms, Transitions, box-sizing or KeyFrames can cause pagination issues.], OPS/style.css (8-23)</message>
    <message severity="info" subMessage="CSS-009">CSS-009, HINT, [Use of certain CSS such as Columns, Transforms, Transitions, box-sizing or KeyFrames can cause pagination issues.], OPS/style_tag_css.xhtml (8-31)</message>
    <message severity="info" subMessage="CSS-009">CSS-009, HINT, [Use of certain CSS such as Columns, Transforms, Transitions, box-sizing or KeyFrames can cause pagination issues.], OPS/style_tag_css.xhtml (13-31)</message>
    <message severity="info" subMessage="CSS-009">CSS-009, HINT, [Use of certain CSS such as Columns, Transforms, Transitions, box-sizing or KeyFrames can cause pagination issues.], OPS/style_tag_css.xhtml (5-28)</message>
-   <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], OPS/inline_css.xhtml (14-116)</message>
    <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], OPS/inline_css.xhtml (10-119)</message>
-   <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], OPS/inline_css.xhtml (15-114)</message>
    <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], OPS/inline_css.xhtml (11-115)</message>
-   <message severity="info" subMessage="ACC-007">ACC-007, HINT, [Content Documents do not use 'epub:type' attributes for semantic inflection.], OPS/external_css.xhtml</message>
-   <message severity="info" subMessage="ACC-007">ACC-007, HINT, [Content Documents do not use 'epub:type' attributes for semantic inflection.], OPS/style_tag_css.xhtml</message>
-   <message severity="info" subMessage="ACC-007">ACC-007, HINT, [Content Documents do not use 'epub:type' attributes for semantic inflection.], OPS/inline_css.xhtml</message>
+   <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], OPS/inline_css.xhtml (14-116)</message>
+   <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], OPS/inline_css.xhtml (15-114)</message>
   </messages>
   <mimeType>application/epub+zip</mimeType>
   <properties>
@@ -51,7 +54,7 @@
      <property>
       <name>CreationDate</name>
       <values arity="Scalar" type="Date">
-       <value>2014-09-05T03:24:40Z</value>
+       <value>2016-12-31T01:11:26Z</value>
       </values>
      </property>
      <property>

--- a/src/test/resources/com/adobe/epubcheck/test/command_line/xmlfile_expected_results.xmp
+++ b/src/test/resources/com/adobe/epubcheck/test/command_line/xmlfile_expected_results.xmp
@@ -1,14 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="Adobe XMP Core 5.1.0-jc003">
  <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-  <rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xmp="http://ns.adobe.com/xap/1.0/" xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/" xmlns:stFnt="http://ns.adobe.com/xap/1.0/sType/Font#" xmlns:extended-properties="http://schemas.openxmlformats.org/officeDocument/2006/extended-properties/" xmlns:premis="http://www.loc.gov/premis/rdf/v1#" dc:format="application/epub+zip;version=3.0.1" xmp:CreateDate="2015-03-30T16:14:34Z" extended-properties:Characters="648" dc:identifier="000000000000000000" dc:language="en">
+  <rdf:Description xmlns:premis="http://www.loc.gov/premis/rdf/v1#"
+                       xmlns:stFnt="http://ns.adobe.com/xap/1.0/sType/Font#"
+                       xmlns:extended-properties="http://schemas.openxmlformats.org/officeDocument/2006/extended-properties/"
+                       xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"
+                       xmlns:xmp="http://ns.adobe.com/xap/1.0/"
+                       xmlns:dc="http://purl.org/dc/elements/1.1/"
+                       dc:format="application/epub+zip;version=3.0.1"
+                       dc:identifier="000000000000000000"
+                       dc:language="en"
+                       extended-properties:Characters="648"
+                       rdf:about=""
+                       xmp:CreateDate="2016-12-31T01:11:26Z">
    <dc:title>
     <rdf:Alt>
      <rdf:li xml:lang="x-default">Transform Sample Book</rdf:li>
     </rdf:Alt>
    </dc:title>
    <premis:hasEvent rdf:parseType="Resource">
-    <premis:hasEventDateTime rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-03-30T23:58:11+02:00</premis:hasEventDateTime>
+    <premis:hasEventDateTime rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-12-31T01:11:58+01:00</premis:hasEventDateTime>
     <premis:hasEventType rdf:resource="http://id.loc.gov/vocabulary/preservation/eventType/val" />
     <premis:hasEventDetail>Well-formed</premis:hasEventDetail>
     <premis:hasEventOutcomeInformation>
@@ -20,6 +31,14 @@
          <rdf:li premis:hasEventOutcomeDetailNote="OPS/external_css.xhtml" />
          <rdf:li premis:hasEventOutcomeDetailNote="OPS/style_tag_css.xhtml" />
          <rdf:li premis:hasEventOutcomeDetailNote="OPS/inline_css.xhtml" />
+        </rdf:Seq>
+       </premis:hasEventOutcomeDetail>
+      </rdf:li>
+      <rdf:li rdf:parseType="Resource">
+       <premis:hasEventOutcome>ACC-008, HINT, Navigation Document has no 'landmarks nav' element.</premis:hasEventOutcome>
+       <premis:hasEventOutcomeDetail>
+        <rdf:Seq>
+         <rdf:li premis:hasEventOutcomeDetailNote="OPS/toc.xhtml"/>
         </rdf:Seq>
        </premis:hasEventOutcomeDetail>
       </rdf:li>
@@ -36,14 +55,6 @@
        <premis:hasEventOutcomeDetail>
         <rdf:Seq>
          <rdf:li premis:hasEventOutcomeDetailNote="OPS/toc.ncx" />
-        </rdf:Seq>
-       </premis:hasEventOutcomeDetail>
-      </rdf:li>
-      <rdf:li rdf:parseType="Resource">
-       <premis:hasEventOutcome>ACC-008, HINT, Navigation Document has no 'landmarks nav' element.</premis:hasEventOutcome>
-       <premis:hasEventOutcomeDetail>
-        <rdf:Seq>
-         <rdf:li premis:hasEventOutcomeDetailNote="xmlfile.epub" />
         </rdf:Seq>
        </premis:hasEventOutcomeDetail>
       </rdf:li>
@@ -74,7 +85,7 @@
     </premis:hasEventOutcomeInformation>
     <premis:hasEventRelatedAgent rdf:parseType="Resource">
      <premis:hasAgentType rdf:resource="http://id.loc.gov/vocabulary/preservation/agentType/sof" />
-     <premis:hasAgentName>epubcheck 4.0.0-alpha12-SNAPSHOT</premis:hasAgentName>
+     <premis:hasAgentName>epubcheck 4.0.3-SNAPSHOT</premis:hasAgentName>
     </premis:hasEventRelatedAgent>
    </premis:hasEvent>
    <premis:hasSignificantProperties>

--- a/src/test/resources/com/adobe/epubcheck/test/css/alternate_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/css/alternate_expected_results.json
@@ -1,11 +1,11 @@
 {
   "customMessageFileName" : null,
   "checker" : {
-    "path" : "./target/test-classes/com/adobe/epubcheck/test/css/alternate.epub",
+    "path" : "./com/adobe/epubcheck/test/css/alternate.epub",
     "filename" : "alternate.epub",
-    "checkerVersion" : "4.0.0-alpha12-SNAPSHOT",
-    "checkDate" : "03-25-2015 10:06:37",
-    "elapsedTime" : 57,
+    "checkerVersion" : "4.0.3-SNAPSHOT",
+    "checkDate" : "12-31-2016 01:11:59",
+    "elapsedTime" : 104,
     "nFatal" : 0,
     "nError" : 1,
     "nWarning" : 0,
@@ -283,7 +283,7 @@
     "message" : "Navigation Document has no 'landmarks nav' element.",
     "additionalLocations" : 0,
     "locations" : [ {
-      "path" : "alternate.epub",
+      "path" : "OPS/toc.xhtml",
       "line" : -1,
       "column" : -1,
       "context" : null

--- a/src/test/resources/com/adobe/epubcheck/test/css/columns_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/css/columns_expected_results.json
@@ -1,11 +1,11 @@
 {
   "customMessageFileName" : null,
   "checker" : {
-    "path" : "./target/test-classes/com/adobe/epubcheck/test/css/columns.epub",
+    "path" : "./com/adobe/epubcheck/test/css/columns.epub",
     "filename" : "columns.epub",
-    "checkerVersion" : "4.0.0-alpha12-SNAPSHOT",
-    "checkDate" : "03-25-2015 10:06:37",
-    "elapsedTime" : 44,
+    "checkerVersion" : "4.0.3-SNAPSHOT",
+    "checkDate" : "12-31-2016 01:11:59",
+    "elapsedTime" : 63,
     "nFatal" : 0,
     "nError" : 0,
     "nWarning" : 0,
@@ -266,7 +266,7 @@
     "message" : "Navigation Document has no 'landmarks nav' element.",
     "additionalLocations" : 0,
     "locations" : [ {
-      "path" : "columns.epub",
+      "path" : "OPS/toc.xhtml",
       "line" : -1,
       "column" : -1,
       "context" : null

--- a/src/test/resources/com/adobe/epubcheck/test/css/discouraged_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/css/discouraged_expected_results.json
@@ -1,11 +1,11 @@
 {
   "customMessageFileName" : null,
   "checker" : {
-    "path" : "./target/test-classes/com/adobe/epubcheck/test/css/discouraged.epub",
+    "path" : "./com/adobe/epubcheck/test/css/discouraged.epub",
     "filename" : "discouraged.epub",
-    "checkerVersion" : "4.0.0-alpha12-SNAPSHOT",
-    "checkDate" : "03-25-2015 10:06:37",
-    "elapsedTime" : 46,
+    "checkerVersion" : "4.0.3-SNAPSHOT",
+    "checkDate" : "12-31-2016 01:11:59",
+    "elapsedTime" : 45,
     "nFatal" : 0,
     "nError" : 2,
     "nWarning" : 2,
@@ -310,7 +310,7 @@
     "message" : "Navigation Document has no 'landmarks nav' element.",
     "additionalLocations" : 0,
     "locations" : [ {
-      "path" : "discouraged.epub",
+      "path" : "OPS/toc.xhtml",
       "line" : -1,
       "column" : -1,
       "context" : null

--- a/src/test/resources/com/adobe/epubcheck/test/css/discouraged_expected_results.xml
+++ b/src/test/resources/com/adobe/epubcheck/test/css/discouraged_expected_results.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jhove xmlns="http://hul.harvard.edu/ois/xml/ns/jhove" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="epubcheck" release="4.0.0-alpha11-SNAPSHOT" date="2012-10-31">
- <date>2014-09-05T03:17:16+02:00</date>
+<jhove xmlns="http://hul.harvard.edu/ois/xml/ns/jhove"
+       date="2016-12-28"
+       name="epubcheck"
+       release="4.0.3-SNAPSHOT">
+ <date>2016-12-31T01:11:59+01:00</date>
  <repInfo uri="discouraged.epub">
-  <created>2014-09-05T01:49:14Z</created>
+  <created>2016-12-31T01:11:26Z</created>
   <lastModified>2012-10-10T12:00:00Z</lastModified>
   <format>application/epub+zip</format>
   <version>3.0.1</version>
@@ -13,18 +16,21 @@
    <message severity="error" subMessage="CSS-001">CSS-001, ERROR, [The 'unicode-bidi' property must not be included in an EPUB Style Sheet.], OPS/style.css (55-5)</message>
    <message severity="error" subMessage="CSS-001">CSS-001, ERROR, [The 'direction' property must not be included in an EPUB Style Sheet.], OPS/inline_css.xhtml (14-22)</message>
    <message severity="error" subMessage="CSS-001">CSS-001, ERROR, [The 'direction' property must not be included in an EPUB Style Sheet.], OPS/style.css (56-5)</message>
-   <message severity="error" subMessage="CSS-017">CSS-017, WARN, [CSS selector specifies absolute position.], OPS/style.css (70-5)</message>
+   <message severity="error" subMessage="CSS-006">CSS-006, WARN, [CSS position:fixed property should not be used in EPUBs.], OPS/style_tag_css.xhtml (38-13)</message>
+         <message severity="error" subMessage="CSS-006">CSS-006, WARN, [CSS position:fixed property should not be used in EPUBs.], OPS/inline_css.xhtml (15-1)</message>
+         <message severity="error" subMessage="CSS-006">CSS-006, WARN, [CSS position:fixed property should not be used in EPUBs.], OPS/style.css (66-5)</message>
+         <message severity="error" subMessage="CSS-017">CSS-017, WARN, [CSS selector specifies absolute position.], OPS/style.css (70-5)</message>
    <message severity="error" subMessage="CSS-017">CSS-017, WARN, [CSS selector specifies absolute position.], OPS/cssStyles.css (2-5)</message>
    <message severity="error" subMessage="CSS-017">CSS-017, WARN, [CSS selector specifies absolute position.], OPS/style_tag_css.xhtml (17-13)</message>
-   <message severity="error" subMessage="CSS-006">CSS-006, WARN, [CSS position:fixed property should not be used in EPUBs.], OPS/style_tag_css.xhtml (38-13)</message>
-   <message severity="error" subMessage="CSS-006">CSS-006, WARN, [CSS position:fixed property should not be used in EPUBs.], OPS/inline_css.xhtml (15-1)</message>
-   <message severity="error" subMessage="CSS-006">CSS-006, WARN, [CSS position:fixed property should not be used in EPUBs.], OPS/style.css (66-5)</message>
-   <message severity="info" subMessage="HTM-010">HTM-010, HINT, [Namespace uri 'http://www.daisy.org/z3986/2005/ncx/' was found.], OPS/toc.ncx (2-68)</message>
+   <message severity="info" subMessage="ACC-007">ACC-007, HINT, [Content Documents do not use 'epub:type' attributes for semantic inflection.], OPS/external_css.xhtml</message>
+   <message severity="info" subMessage="ACC-007">ACC-007, HINT, [Content Documents do not use 'epub:type' attributes for semantic inflection.], OPS/style_tag_css.xhtml</message>
+   <message severity="info" subMessage="ACC-007">ACC-007, HINT, [Content Documents do not use 'epub:type' attributes for semantic inflection.], OPS/inline_css.xhtml</message>
+   <message severity="info" subMessage="ACC-008">ACC-008, HINT, [Navigation Document has no 'landmarks nav' element.], OPS/toc.xhtml</message>
+         <message severity="info" subMessage="HTM-010">HTM-010, HINT, [Namespace uri 'http://www.daisy.org/z3986/2005/ncx/' was found.], OPS/toc.ncx (2-68)</message>
    <message severity="info" subMessage="OPF-059">OPF-059, HINT, [Spine item has no NCX entry reference.], OPS/toc.ncx</message>
    <message severity="info" subMessage="OPF-059">OPF-059, HINT, [Spine item has no NCX entry reference.], OPS/toc.ncx</message>
    <message severity="info" subMessage="CSS-012">CSS-012, HINT, [Document links to multiple CSS files.], OPS/external_css.xhtml (6-62)</message>
    <message severity="info" subMessage="CSS-012">CSS-012, HINT, [Document links to multiple CSS files.], OPS/external_css.xhtml (7-66)</message>
-   <message severity="info" subMessage="ACC-008">ACC-008, HINT, [Navigation Document has no 'landmarks nav' element.], discouraged.epub</message>
    <message severity="info" subMessage="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size.], OPS/style.css (2-5)</message>
    <message severity="info" subMessage="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size.], OPS/style.css (7-5)</message>
    <message severity="info" subMessage="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size.], OPS/style.css (15-5)</message>
@@ -56,33 +62,30 @@
    <message severity="info" subMessage="CSS-023">CSS-023, HINT, [CSS selector specifies media query.], OPS/style_tag_css.xhtml (20-9)</message>
    <message severity="info" subMessage="CSS-025">CSS-025, HINT, [CSS class Selector could not be found.], OPS/style_tag_css.xhtml (54-24)</message>
    <message severity="info" subMessage="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/style_tag_css.xhtml (14-9)</message>
-   <message severity="info" subMessage="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/unused.css (1-1)</message>
-   <message severity="info" subMessage="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/style.css (22-1)</message>
-   <message severity="info" subMessage="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/style.css (14-1)</message>
+   <message severity="info" subMessage="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/style.css (6-1)</message>
    <message severity="info" subMessage="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/style.css (10-1)</message>
+   <message severity="info" subMessage="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/style.css (14-1)</message>
    <message severity="info" subMessage="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/style.css (18-1)</message>
-   <message severity="info" subMessage="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/style.css (34-1)</message>
+   <message severity="info" subMessage="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/style.css (22-1)</message>
+         <message severity="info" subMessage="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/style.css (30-1)</message>
+         <message severity="info" subMessage="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/style.css (34-1)</message>
    <message severity="info" subMessage="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/style.css (38-1)</message>
    <message severity="info" subMessage="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/style.css (42-1)</message>
    <message severity="info" subMessage="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/style.css (46-1)</message>
-   <message severity="info" subMessage="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/unused.css (30-1)</message>
-   <message severity="info" subMessage="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/style.css (6-1)</message>
-   <message severity="info" subMessage="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/style.css (30-1)</message>
-   <message severity="info" subMessage="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/unused.css (56-1)</message>
    <message severity="info" subMessage="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/style.css (82-1)</message>
-   <message severity="info" subMessage="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/unused.css (49-1)</message>
-   <message severity="info" subMessage="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/unused.css (36-1)</message>
    <message severity="info" subMessage="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/style.css (98-5)</message>
+   <message severity="info" subMessage="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/unused.css (1-1)</message>
+   <message severity="info" subMessage="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/unused.css (30-1)</message>
+   <message severity="info" subMessage="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/unused.css (36-1)</message>
+   <message severity="info" subMessage="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/unused.css (49-1)</message>
+   <message severity="info" subMessage="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/unused.css (56-1)</message>
    <message severity="info" subMessage="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/unused.css (62-1)</message>
    <message severity="info" subMessage="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/unused.css (66-3)</message>
    <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], OPS/inline_css.xhtml (10-54)</message>
    <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], OPS/inline_css.xhtml (11-97)</message>
    <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], OPS/inline_css.xhtml (14-50)</message>
    <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], OPS/inline_css.xhtml (15-41)</message>
-   <message severity="info" subMessage="ACC-007">ACC-007, HINT, [Content Documents do not use 'epub:type' attributes for semantic inflection.], OPS/external_css.xhtml</message>
-   <message severity="info" subMessage="ACC-007">ACC-007, HINT, [Content Documents do not use 'epub:type' attributes for semantic inflection.], OPS/style_tag_css.xhtml</message>
-   <message severity="info" subMessage="ACC-007">ACC-007, HINT, [Content Documents do not use 'epub:type' attributes for semantic inflection.], OPS/inline_css.xhtml</message>
-  </messages>
+   </messages>
   <mimeType>application/epub+zip</mimeType>
   <properties>
    <property>
@@ -109,7 +112,7 @@
      <property>
       <name>CreationDate</name>
       <values arity="Scalar" type="Date">
-       <value>2014-09-05T01:49:14Z</value>
+       <value>2016-12-31T01:11:26Z</value>
       </values>
      </property>
      <property>

--- a/src/test/resources/com/adobe/epubcheck/test/css/excessive_epub3_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/css/excessive_epub3_expected_results.json
@@ -3,9 +3,9 @@
   "checker" : {
     "path" : "./com/adobe/epubcheck/test/css/excessive_epub3.epub",
     "filename" : "excessive_epub3.epub",
-    "checkerVersion" : "4.0.0-alpha11-SNAPSHOT",
-    "checkDate" : "09-05-2014 03:17:17",
-    "elapsedTime" : 213,
+    "checkerVersion" : "4.0.3-SNAPSHOT",
+    "checkDate" : "12-31-2016 01:11:59",
+    "elapsedTime" : 48,
     "nFatal" : 0,
     "nError" : 0,
     "nWarning" : 0,
@@ -432,7 +432,7 @@
     "message" : "Navigation Document has no 'landmarks nav' element.",
     "additionalLocations" : 0,
     "locations" : [ {
-      "path" : "excessive_epub3.epub",
+      "path" : "OPS/toc.xhtml",
       "line" : -1,
       "column" : -1,
       "context" : null

--- a/src/test/resources/com/adobe/epubcheck/test/css/font-face_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/css/font-face_expected_results.json
@@ -1,11 +1,11 @@
 {
   "customMessageFileName" : null,
   "checker" : {
-    "path" : "./target/test-classes/com/adobe/epubcheck/test/css/font-face.epub",
+    "path" : "./com/adobe/epubcheck/test/css/font-face.epub",
     "filename" : "font-face.epub",
     "checkerVersion" : "4.0.3-SNAPSHOT",
-    "checkDate" : "12-18-2016 16:57:07",
-    "elapsedTime" : 53,
+    "checkDate" : "12-31-2016 01:11:59",
+    "elapsedTime" : 58,
     "nFatal" : 0,
     "nError" : 5,
     "nWarning" : 1,
@@ -332,7 +332,7 @@
     "message" : "Navigation Document has no 'landmarks nav' element.",
     "additionalLocations" : 0,
     "locations" : [ {
-      "path" : "font-face.epub",
+      "path" : "OPS/toc.xhtml",
       "line" : -1,
       "column" : -1,
       "context" : null

--- a/src/test/resources/com/adobe/epubcheck/test/css/font-face_expected_results.xmp
+++ b/src/test/resources/com/adobe/epubcheck/test/css/font-face_expected_results.xmp
@@ -1,7 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="Adobe XMP Core 5.1.0-jc003">
  <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-  <rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xmp="http://ns.adobe.com/xap/1.0/" xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/" xmlns:stFnt="http://ns.adobe.com/xap/1.0/sType/Font#" xmlns:extended-properties="http://schemas.openxmlformats.org/officeDocument/2006/extended-properties/" xmlns:premis="http://www.loc.gov/premis/rdf/v1#" dc:format="application/epub+zip;version=3.0.1" xmp:CreateDate="2015-03-30T16:14:34Z" extended-properties:Characters="2205" dc:identifier="000000000000000000" dc:language="en">
+  <rdf:Description xmlns:premis="http://www.loc.gov/premis/rdf/v1#"
+                       xmlns:stFnt="http://ns.adobe.com/xap/1.0/sType/Font#"
+                       xmlns:extended-properties="http://schemas.openxmlformats.org/officeDocument/2006/extended-properties/"
+                       xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"
+                       xmlns:xmp="http://ns.adobe.com/xap/1.0/"
+                       xmlns:dc="http://purl.org/dc/elements/1.1/"
+                       dc:format="application/epub+zip;version=3.0.1"
+                       dc:identifier="000000000000000000"
+                       dc:language="en"
+                       extended-properties:Characters="2205"
+                       rdf:about=""
+                       xmp:CreateDate="2016-12-31T01:11:26Z">
    <dc:title>
     <rdf:Alt>
      <rdf:li xml:lang="x-default">Font Face Sample Book</rdf:li>
@@ -9,18 +20,18 @@
    </dc:title>
    <xmpTPg:Fonts>
     <rdf:Bag>
-     <rdf:li stFnt:fontFamily="Bloody" stFnt:fontFace="Regular" />
-     <rdf:li stFnt:fontFamily="Badaboom" stFnt:fontFace="Regular" />
-     <rdf:li stFnt:fontFamily="Brankovic" stFnt:fontFace="Regular" />
-     <rdf:li stFnt:fontFamily="Fummel" stFnt:fontFace="Regular" />
-     <rdf:li stFnt:fontFamily="Null" stFnt:fontFace="Regular" />
-     <rdf:li stFnt:fontFamily="Bloody_wrong" stFnt:fontFace="Regular" />
-     <rdf:li stFnt:fontFamily="Chela One" stFnt:fontFace="400" />
-     <rdf:li stFnt:fontFamily="Bitstream Vera Serif Bold" stFnt:fontFace="Regular" />
+     <rdf:li stFnt:fontFace="Regular" stFnt:fontFamily="Bloody"/>
+     <rdf:li stFnt:fontFace="Regular" stFnt:fontFamily="Badaboom"/>
+     <rdf:li stFnt:fontFace="Regular" stFnt:fontFamily="Brankovic"/>
+     <rdf:li stFnt:fontFace="Regular" stFnt:fontFamily="Fummel"/>
+     <rdf:li stFnt:fontFace="Regular" stFnt:fontFamily="Null"/>
+     <rdf:li stFnt:fontFace="Regular" stFnt:fontFamily="Bloody_wrong"/>
+     <rdf:li stFnt:fontFace="400" stFnt:fontFamily="Chela One"/>
+     <rdf:li stFnt:fontFace="Regular" stFnt:fontFamily="Bitstream Vera Serif Bold"/>
     </rdf:Bag>
    </xmpTPg:Fonts>
    <premis:hasEvent rdf:parseType="Resource">
-    <premis:hasEventDateTime rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-12-18T16:57:07+01:00</premis:hasEventDateTime>
+    <premis:hasEventDateTime rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-12-31T01:11:59+01:00</premis:hasEventDateTime>
     <premis:hasEventType rdf:resource="http://id.loc.gov/vocabulary/preservation/eventType/val" />
     <premis:hasEventDetail>Not well-formed</premis:hasEventDetail>
     <premis:hasEventOutcomeInformation>
@@ -124,10 +135,18 @@
        </premis:hasEventOutcomeDetail>
       </rdf:li>
       <rdf:li rdf:parseType="Resource">
+       <premis:hasEventOutcome>ACC-008, HINT, Navigation Document has no 'landmarks nav' element.</premis:hasEventOutcome>
+       <premis:hasEventOutcomeDetail>
+        <rdf:Seq>
+         <rdf:li premis:hasEventOutcomeDetailNote="OPS/toc.xhtml"/>
+        </rdf:Seq>
+       </premis:hasEventOutcomeDetail>
+      </rdf:li>
+      <rdf:li rdf:parseType="Resource">
        <premis:hasEventOutcome>HTM-010, HINT, Namespace uri 'http://www.daisy.org/z3986/2005/ncx/' was found.</premis:hasEventOutcome>
        <premis:hasEventOutcomeDetail>
         <rdf:Seq>
-         <rdf:li premis:hasEventOutcomeDetailNote="OPS/toc.ncx (2-68)" />
+         <rdf:li premis:hasEventOutcomeDetailNote="OPS/toc.ncx (2-68)"/>
         </rdf:Seq>
        </premis:hasEventOutcomeDetail>
       </rdf:li>
@@ -135,25 +154,17 @@
        <premis:hasEventOutcome>OPF-059, HINT, Spine item has no NCX entry reference.</premis:hasEventOutcome>
        <premis:hasEventOutcomeDetail>
         <rdf:Seq>
-         <rdf:li premis:hasEventOutcomeDetailNote="OPS/toc.ncx" />
-        </rdf:Seq>
+         <rdf:li premis:hasEventOutcomeDetailNote="OPS/toc.ncx"/>
+         </rdf:Seq>
        </premis:hasEventOutcomeDetail>
       </rdf:li>
       <rdf:li rdf:parseType="Resource">
        <premis:hasEventOutcome>CSS-012, HINT, Document links to multiple CSS files.</premis:hasEventOutcome>
        <premis:hasEventOutcomeDetail>
         <rdf:Seq>
-         <rdf:li premis:hasEventOutcomeDetailNote="OPS/external_css.xhtml (6-69)" />
-         <rdf:li premis:hasEventOutcomeDetailNote="OPS/external_css.xhtml (7-101)" />
-        </rdf:Seq>
-       </premis:hasEventOutcomeDetail>
-      </rdf:li>
-      <rdf:li rdf:parseType="Resource">
-       <premis:hasEventOutcome>ACC-008, HINT, Navigation Document has no 'landmarks nav' element.</premis:hasEventOutcome>
-       <premis:hasEventOutcomeDetail>
-        <rdf:Seq>
-         <rdf:li premis:hasEventOutcomeDetailNote="font-face.epub" />
-        </rdf:Seq>
+         <rdf:li premis:hasEventOutcomeDetailNote="OPS/external_css.xhtml (6-69)"/>
+        <rdf:li premis:hasEventOutcomeDetailNote="OPS/external_css.xhtml (7-101)"/>
+                        </rdf:Seq>
        </premis:hasEventOutcomeDetail>
       </rdf:li>
       <rdf:li rdf:parseType="Resource">

--- a/src/test/resources/com/adobe/epubcheck/test/css/font_encryption_idpf_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/css/font_encryption_idpf_expected_results.json
@@ -1,11 +1,11 @@
 {
   "customMessageFileName" : null,
   "checker" : {
-    "path" : "./target/test-classes/com/adobe/epubcheck/test/css/font_encryption_idpf.epub",
+    "path" : "./com/adobe/epubcheck/test/css/font_encryption_idpf.epub",
     "filename" : "font_encryption_idpf.epub",
-    "checkerVersion" : "4.0.0-alpha12-SNAPSHOT",
-    "checkDate" : "03-25-2015 10:06:38",
-    "elapsedTime" : 400,
+    "checkerVersion" : "4.0.3-SNAPSHOT",
+    "checkDate" : "12-31-2016 01:11:59",
+    "elapsedTime" : 423,
     "nFatal" : 0,
     "nError" : 0,
     "nWarning" : 0,
@@ -557,7 +557,7 @@
     "message" : "Navigation Document has no 'landmarks nav' element.",
     "additionalLocations" : 0,
     "locations" : [ {
-      "path" : "font_encryption_idpf.epub",
+      "path" : "Css-fontface/pages/toc.xhtml",
       "line" : -1,
       "column" : -1,
       "context" : null

--- a/src/test/resources/com/adobe/epubcheck/test/css/font_encryption_idpf_expected_results.xml
+++ b/src/test/resources/com/adobe/epubcheck/test/css/font_encryption_idpf_expected_results.xml
@@ -1,30 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jhove xmlns="http://hul.harvard.edu/ois/xml/ns/jhove" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="epubcheck" release="4.0.0-alpha11-SNAPSHOT" date="2012-10-31">
- <date>2014-09-05T03:17:19+02:00</date>
+<jhove xmlns="http://hul.harvard.edu/ois/xml/ns/jhove"
+       date="2016-12-28"
+       name="epubcheck"
+       release="4.0.3-SNAPSHOT">
+ <date>2016-12-31T01:12:00+01:00</date>
  <repInfo uri="font_encryption_idpf.epub">
-  <created>2014-09-05T01:49:14Z</created>
+  <created>2016-12-31T01:11:26Z</created>
   <lastModified>2012-01-20T12:47:00Z</lastModified>
   <format>application/epub+zip</format>
   <version>3.0.1</version>
   <status>Well-formed</status>
   <messages>
-   <message severity="info" subMessage="OPF-058">OPF-058, HINT, [Spine item has no TOC entry reference.], Css-fontface/pages/toc.xhtml</message>
-   <message severity="info" subMessage="ACC-008">ACC-008, HINT, [Navigation Document has no 'landmarks nav' element.], font_encryption_idpf.epub</message>
-   <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg1.xhtml (23-56)</message>
-   <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg1.xhtml (33-44)</message>
-   <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg1.xhtml (11-51)</message>
-   <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg1.xhtml (19-55)</message>
-   <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg1.xhtml (15-52)</message>
-   <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg2.xhtml (11-68)</message>
-   <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg2.xhtml (35-61)</message>
-   <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg2.xhtml (15-69)</message>
-   <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg2.xhtml (19-72)</message>
-   <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg2.xhtml (23-73)</message>
-   <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg3.xhtml (11-69)</message>
-   <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg3.xhtml (35-62)</message>
-   <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg3.xhtml (15-70)</message>
-   <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg3.xhtml (23-74)</message>
-   <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg3.xhtml (19-73)</message>
    <message severity="info" subMessage="ACC-007">ACC-007, HINT, [Content Documents do not use 'epub:type' attributes for semantic inflection.], Css-fontface/pages/cover.xhtml</message>
    <message severity="info" subMessage="ACC-007">ACC-007, HINT, [Content Documents do not use 'epub:type' attributes for semantic inflection.], Css-fontface/pages/pg1.xhtml</message>
    <message severity="info" subMessage="ACC-007">ACC-007, HINT, [Content Documents do not use 'epub:type' attributes for semantic inflection.], Css-fontface/pages/pg2.xhtml</message>
@@ -55,7 +41,24 @@
    <message severity="info" subMessage="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (40-5)</message>
    <message severity="info" subMessage="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (43-5)</message>
    <message severity="info" subMessage="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], There are 23 additional locations for this message.</message>
-  </messages>
+  <message severity="info" subMessage="ACC-008">ACC-008, HINT, [Navigation Document has no 'landmarks nav' element.], Css-fontface/pages/toc.xhtml</message>
+         <message severity="info" subMessage="OPF-058">OPF-058, HINT, [Spine item has no TOC entry reference.], Css-fontface/pages/toc.xhtml</message>
+         <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg1.xhtml (11-51)</message>
+         <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg1.xhtml (15-52)</message>
+         <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg1.xhtml (19-55)</message>
+         <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg1.xhtml (23-56)</message>
+         <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg1.xhtml (33-44)</message>
+         <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg2.xhtml (11-68)</message>
+         <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg2.xhtml (15-69)</message>
+         <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg2.xhtml (19-72)</message>
+         <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg2.xhtml (23-73)</message>
+         <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg2.xhtml (35-61)</message>
+         <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg3.xhtml (11-69)</message>
+         <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg3.xhtml (15-70)</message>
+         <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg3.xhtml (19-73)</message>
+         <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg3.xhtml (23-74)</message>
+         <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg3.xhtml (35-62)</message>
+      </messages>
   <mimeType>application/epub+zip</mimeType>
   <properties>
    <property>
@@ -82,7 +85,7 @@
      <property>
       <name>CreationDate</name>
       <values arity="Scalar" type="Date">
-       <value>2014-09-05T01:49:14Z</value>
+       <value>2016-12-31T01:11:26Z</value>
       </values>
      </property>
      <property>

--- a/src/test/resources/com/adobe/epubcheck/test/css/font_encryption_idpf_expected_results.xmp
+++ b/src/test/resources/com/adobe/epubcheck/test/css/font_encryption_idpf_expected_results.xmp
@@ -1,7 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="Adobe XMP Core 5.1.0-jc003">
  <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-  <rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xmp="http://ns.adobe.com/xap/1.0/" xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/" xmlns:stFnt="http://ns.adobe.com/xap/1.0/sType/Font#" xmlns:extended-properties="http://schemas.openxmlformats.org/officeDocument/2006/extended-properties/" xmlns:premis="http://www.loc.gov/premis/rdf/v1#" dc:format="application/epub+zip;version=3.0.1" xmp:CreateDate="2015-03-30T16:14:34Z" extended-properties:Characters="2904" dc:publisher="Epub3 Team" dc:identifier="epub3.test" dc:language="en-US">
+  <rdf:Description xmlns:premis="http://www.loc.gov/premis/rdf/v1#"
+                       xmlns:stFnt="http://ns.adobe.com/xap/1.0/sType/Font#"
+                       xmlns:extended-properties="http://schemas.openxmlformats.org/officeDocument/2006/extended-properties/"
+                       xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"
+                       xmlns:xmp="http://ns.adobe.com/xap/1.0/"
+                       xmlns:dc="http://purl.org/dc/elements/1.1/"
+                       dc:format="application/epub+zip;version=3.0.1"
+                       dc:identifier="epub3.test"
+                       dc:language="en-US"
+                       dc:publisher="Epub3 Team"
+                       extended-properties:Characters="2904"
+                       rdf:about=""
+                       xmp:CreateDate="2016-12-31T01:11:26Z">
    <dc:creator>
     <rdf:Seq>
      <rdf:li>David</rdf:li>
@@ -14,22 +26,22 @@
    </dc:title>
    <xmpTPg:Fonts>
     <rdf:Bag>
-     <rdf:li stFnt:fontFamily="OS-obf-otf" stFnt:fontFace="Regular" />
-     <rdf:li stFnt:fontFamily="OS-obf-otf" stFnt:fontFace="Bold" />
-     <rdf:li stFnt:fontFamily="OS-obf-otf" stFnt:fontFace="Italic" />
-     <rdf:li stFnt:fontFamily="OS-woff" stFnt:fontFace="Regular" />
-     <rdf:li stFnt:fontFamily="OS-woff" stFnt:fontFace="Bold" />
-     <rdf:li stFnt:fontFamily="OS-woff" stFnt:fontFace="Italic" />
-     <rdf:li stFnt:fontFamily="OS-obf-woff" stFnt:fontFace="Regular" />
-     <rdf:li stFnt:fontFamily="OS-obf-woff" stFnt:fontFace="Bold" />
-     <rdf:li stFnt:fontFamily="OS-obf-woff" stFnt:fontFace="Italic" />
-     <rdf:li stFnt:fontFamily="OS-otf" stFnt:fontFace="Regular" />
-     <rdf:li stFnt:fontFamily="OS-otf" stFnt:fontFace="Bold" />
-     <rdf:li stFnt:fontFamily="OS-otf" stFnt:fontFace="Italic" />
+     <rdf:li stFnt:fontFace="Regular" stFnt:fontFamily="OS-obf-otf"/>
+     <rdf:li stFnt:fontFace="Bold" stFnt:fontFamily="OS-obf-otf"/>
+     <rdf:li stFnt:fontFace="Italic" stFnt:fontFamily="OS-obf-otf"/>
+     <rdf:li stFnt:fontFace="Regular" stFnt:fontFamily="OS-woff"/>
+     <rdf:li stFnt:fontFace="Bold" stFnt:fontFamily="OS-woff"/>
+     <rdf:li stFnt:fontFace="Italic" stFnt:fontFamily="OS-woff"/>
+     <rdf:li stFnt:fontFace="Regular" stFnt:fontFamily="OS-obf-woff"/>
+     <rdf:li stFnt:fontFace="Bold" stFnt:fontFamily="OS-obf-woff"/>
+     <rdf:li stFnt:fontFace="Italic" stFnt:fontFamily="OS-obf-woff"/>
+     <rdf:li stFnt:fontFace="Regular" stFnt:fontFamily="OS-otf"/>
+     <rdf:li stFnt:fontFace="Bold" stFnt:fontFamily="OS-otf"/>
+     <rdf:li stFnt:fontFace="Italic" stFnt:fontFamily="OS-otf"/>
     </rdf:Bag>
    </xmpTPg:Fonts>
    <premis:hasEvent rdf:parseType="Resource">
-    <premis:hasEventDateTime rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-03-30T16:15:04+02:00</premis:hasEventDateTime>
+    <premis:hasEventDateTime rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-12-31T01:12:01+01:00</premis:hasEventDateTime>
     <premis:hasEventType rdf:resource="http://id.loc.gov/vocabulary/preservation/eventType/val" />
     <premis:hasEventDetail>Well-formed</premis:hasEventDetail>
     <premis:hasEventOutcomeInformation>
@@ -79,7 +91,7 @@
        </premis:hasEventOutcomeDetail>
       </rdf:li>
       <rdf:li rdf:parseType="Resource">
-       <premis:hasEventOutcome>OPF-058, HINT, Spine item has no TOC entry reference.</premis:hasEventOutcome>
+       <premis:hasEventOutcome>ACC-008, HINT, Navigation Document has no 'landmarks nav' element.</premis:hasEventOutcome>
        <premis:hasEventOutcomeDetail>
         <rdf:Seq>
          <rdf:li premis:hasEventOutcomeDetailNote="Css-fontface/pages/toc.xhtml" />
@@ -87,10 +99,10 @@
        </premis:hasEventOutcomeDetail>
       </rdf:li>
       <rdf:li rdf:parseType="Resource">
-       <premis:hasEventOutcome>ACC-008, HINT, Navigation Document has no 'landmarks nav' element.</premis:hasEventOutcome>
+       <premis:hasEventOutcome>OPF-058, HINT, Spine item has no TOC entry reference.</premis:hasEventOutcome>
        <premis:hasEventOutcomeDetail>
         <rdf:Seq>
-         <rdf:li premis:hasEventOutcomeDetailNote="font_encryption_idpf.epub" />
+         <rdf:li premis:hasEventOutcomeDetailNote="Css-fontface/pages/toc.xhtml"/>
         </rdf:Seq>
        </premis:hasEventOutcomeDetail>
       </rdf:li>
@@ -120,7 +132,7 @@
     </premis:hasEventOutcomeInformation>
     <premis:hasEventRelatedAgent rdf:parseType="Resource">
      <premis:hasAgentType rdf:resource="http://id.loc.gov/vocabulary/preservation/agentType/sof" />
-     <premis:hasAgentName>epubcheck 4.0.0-alpha12-SNAPSHOT</premis:hasAgentName>
+     <premis:hasAgentName>epubcheck 4.0.3-SNAPSHOT</premis:hasAgentName>
     </premis:hasEventRelatedAgent>
    </premis:hasEvent>
    <premis:hasSignificantProperties>

--- a/src/test/resources/com/adobe/epubcheck/test/css/keyframe_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/css/keyframe_expected_results.json
@@ -1,11 +1,11 @@
 {
   "customMessageFileName" : null,
   "checker" : {
-    "path" : "./target/test-classes/com/adobe/epubcheck/test/css/keyframe.epub",
+    "path" : "./com/adobe/epubcheck/test/css/keyframe.epub",
     "filename" : "keyframe.epub",
-    "checkerVersion" : "4.0.0-alpha12-SNAPSHOT",
-    "checkDate" : "03-25-2015 10:06:37",
-    "elapsedTime" : 46,
+    "checkerVersion" : "4.0.3-SNAPSHOT",
+    "checkDate" : "12-31-2016 01:11:59",
+    "elapsedTime" : 48,
     "nFatal" : 0,
     "nError" : 0,
     "nWarning" : 0,
@@ -266,7 +266,7 @@
     "message" : "Navigation Document has no 'landmarks nav' element.",
     "additionalLocations" : 0,
     "locations" : [ {
-      "path" : "keyframe.epub",
+      "path" : "OPS/toc.xhtml",
       "line" : -1,
       "column" : -1,
       "context" : null

--- a/src/test/resources/com/adobe/epubcheck/test/css/multiple_epub3_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/css/multiple_epub3_expected_results.json
@@ -1,11 +1,11 @@
 {
   "customMessageFileName" : null,
   "checker" : {
-    "path" : "./target/test-classes/com/adobe/epubcheck/test/css/multiple_epub3.epub",
+    "path" : "./com/adobe/epubcheck/test/css/multiple_epub3.epub",
     "filename" : "multiple_epub3.epub",
-    "checkerVersion" : "4.0.0-alpha12-SNAPSHOT",
-    "checkDate" : "03-25-2015 10:06:37",
-    "elapsedTime" : 42,
+    "checkerVersion" : "4.0.3-SNAPSHOT",
+    "checkDate" : "12-31-2016 01:11:59",
+    "elapsedTime" : 51,
     "nFatal" : 0,
     "nError" : 1,
     "nWarning" : 0,
@@ -310,7 +310,7 @@
     "message" : "Navigation Document has no 'landmarks nav' element.",
     "additionalLocations" : 0,
     "locations" : [ {
-      "path" : "multiple_epub3.epub",
+      "path" : "OPS/toc.xhtml",
       "line" : -1,
       "column" : -1,
       "context" : null

--- a/src/test/resources/com/adobe/epubcheck/test/css/transform_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/css/transform_expected_results.json
@@ -1,11 +1,11 @@
 {
   "customMessageFileName" : null,
   "checker" : {
-    "path" : "./target/test-classes/com/adobe/epubcheck/test/css/transform.epub",
+    "path" : "./com/adobe/epubcheck/test/css/transform.epub",
     "filename" : "transform.epub",
-    "checkerVersion" : "4.0.0-alpha12-SNAPSHOT",
-    "checkDate" : "03-25-2015 10:06:37",
-    "elapsedTime" : 44,
+    "checkerVersion" : "4.0.3-SNAPSHOT",
+    "checkDate" : "12-31-2016 01:11:59",
+    "elapsedTime" : 43,
     "nFatal" : 0,
     "nError" : 0,
     "nWarning" : 0,
@@ -266,7 +266,7 @@
     "message" : "Navigation Document has no 'landmarks nav' element.",
     "additionalLocations" : 0,
     "locations" : [ {
-      "path" : "transform.epub",
+      "path" : "OPS/toc.xhtml",
       "line" : -1,
       "column" : -1,
       "context" : null

--- a/src/test/resources/com/adobe/epubcheck/test/css/transition_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/css/transition_expected_results.json
@@ -1,11 +1,11 @@
 {
   "customMessageFileName" : null,
   "checker" : {
-    "path" : "./target/test-classes/com/adobe/epubcheck/test/css/transition.epub",
+    "path" : "./com/adobe/epubcheck/test/css/transition.epub",
     "filename" : "transition.epub",
-    "checkerVersion" : "4.0.0-alpha12-SNAPSHOT",
-    "checkDate" : "03-25-2015 10:06:37",
-    "elapsedTime" : 43,
+    "checkerVersion" : "4.0.3-SNAPSHOT",
+    "checkDate" : "12-31-2016 01:11:59",
+    "elapsedTime" : 45,
     "nFatal" : 0,
     "nError" : 0,
     "nWarning" : 0,
@@ -266,7 +266,7 @@
     "message" : "Navigation Document has no 'landmarks nav' element.",
     "additionalLocations" : 0,
     "locations" : [ {
-      "path" : "transition.epub",
+      "path" : "OPS/toc.xhtml",
       "line" : -1,
       "column" : -1,
       "context" : null

--- a/src/test/resources/com/adobe/epubcheck/test/opf/Epub2_marked_v3_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/opf/Epub2_marked_v3_expected_results.json
@@ -3,13 +3,13 @@
   "checker" : {
     "path" : "./com/adobe/epubcheck/test/opf/Epub2_marked_v3.epub",
     "filename" : "Epub2_marked_v3.epub",
-    "checkerVersion" : "4.0.0-alpha11-SNAPSHOT",
-    "checkDate" : "09-05-2014 03:15:42",
-    "elapsedTime" : 222,
+    "checkerVersion" : "4.0.3-SNAPSHOT",
+    "checkDate" : "12-31-2016 01:12:02",
+    "elapsedTime" : 25,
     "nFatal" : 0,
     "nError" : 3,
     "nWarning" : 0,
-    "nUsage" : 3
+    "nUsage" : 2
   },
   "publication" : {
     "publisher" : null,
@@ -157,18 +157,6 @@
     "additionalLocations" : 0,
     "locations" : [ {
       "path" : "OPS/page01.xhtml",
-      "line" : -1,
-      "column" : -1,
-      "context" : null
-    } ],
-    "suggestion" : null
-  }, {
-    "ID" : "ACC-008",
-    "severity" : "USAGE",
-    "message" : "Navigation Document has no 'landmarks nav' element.",
-    "additionalLocations" : 0,
-    "locations" : [ {
-      "path" : "Epub2_marked_v3.epub",
       "line" : -1,
       "column" : -1,
       "context" : null

--- a/src/test/resources/com/adobe/epubcheck/test/opf/Epub2_marked_v3_expected_results.xml
+++ b/src/test/resources/com/adobe/epubcheck/test/opf/Epub2_marked_v3_expected_results.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jhove xmlns="http://hul.harvard.edu/ois/xml/ns/jhove" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="epubcheck" release="4.0.0-alpha11-SNAPSHOT" date="2012-10-31">
- <date>2014-09-05T03:15:43+02:00</date>
+<jhove xmlns="http://hul.harvard.edu/ois/xml/ns/jhove"
+       date="2016-12-28"
+       name="epubcheck"
+       release="4.0.3-SNAPSHOT">
+ <date>2016-12-31T01:12:02+01:00</date>
  <repInfo uri="Epub2_marked_v3.epub">
-  <created>2014-09-05T01:49:14Z</created>
+  <created>2016-12-31T01:11:26Z</created>
   <format>application/epub+zip</format>
   <version>3.0.1</version>
   <status>Not well-formed</status>
@@ -10,10 +13,9 @@
    <message severity="error" subMessage="RSC-005">RSC-005, ERROR, [Error while parsing file 'package dcterms:modified meta element must occur exactly once'.], OPS/content.opf (3-57)</message>
    <message severity="error" subMessage="RSC-005">RSC-005, ERROR, [Error while parsing file 'Exactly one manifest item must declare the 'nav' property (number of 'nav' items: 0).'.], OPS/content.opf (8-13)</message>
    <message severity="error" subMessage="HTM-004">HTM-004, ERROR, [Irregular DOCTYPE: found '-//W3C//DTD XHTML 1.1//EN', expected '&lt;!DOCTYPE html&gt;'.], OPS/page01.xhtml</message>
-   <message severity="info" subMessage="HTM-010">HTM-010, HINT, [Namespace uri 'http://www.daisy.org/z3986/2005/ncx/' was found.], OPS/toc.ncx (2-68)</message>
-   <message severity="info" subMessage="ACC-008">ACC-008, HINT, [Navigation Document has no 'landmarks nav' element.], Epub2_marked_v3.epub</message>
    <message severity="info" subMessage="ACC-007">ACC-007, HINT, [Content Documents do not use 'epub:type' attributes for semantic inflection.], OPS/page01.xhtml</message>
-  </messages>
+   <message severity="info" subMessage="HTM-010">HTM-010, HINT, [Namespace uri 'http://www.daisy.org/z3986/2005/ncx/' was found.], OPS/toc.ncx (2-68)</message>
+   </messages>
   <mimeType>application/epub+zip</mimeType>
   <properties>
    <property>
@@ -40,7 +42,7 @@
      <property>
       <name>CreationDate</name>
       <values arity="Scalar" type="Date">
-       <value>2014-09-05T01:49:14Z</value>
+       <value>2016-12-31T01:11:26Z</value>
       </values>
      </property>
      <property>

--- a/src/test/resources/com/adobe/epubcheck/test/opf/Excessive_Spine_Items_epub3_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/opf/Excessive_Spine_Items_epub3_expected_results.json
@@ -3,9 +3,9 @@
   "checker" : {
     "path" : "./com/adobe/epubcheck/test/opf/Excessive_Spine_Items_epub3.epub",
     "filename" : "Excessive_Spine_Items_epub3.epub",
-    "checkerVersion" : "4.0.0-alpha11-SNAPSHOT",
-    "checkDate" : "09-05-2014 03:15:44",
-    "elapsedTime" : 956,
+    "checkerVersion" : "4.0.3-SNAPSHOT",
+    "checkDate" : "12-31-2016 01:12:02",
+    "elapsedTime" : 440,
     "nFatal" : 0,
     "nError" : 0,
     "nWarning" : 0,
@@ -2493,7 +2493,7 @@
     "message" : "Navigation Document has no 'landmarks nav' element.",
     "additionalLocations" : 0,
     "locations" : [ {
-      "path" : "Excessive_Spine_Items_epub3.epub",
+      "path" : "OPS/toc.xhtml",
       "line" : -1,
       "column" : -1,
       "context" : null

--- a/src/test/resources/com/adobe/epubcheck/test/opf/Excessive_Spine_Items_epub3_fixed_format_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/opf/Excessive_Spine_Items_epub3_fixed_format_expected_results.json
@@ -3,9 +3,9 @@
   "checker" : {
     "path" : "./com/adobe/epubcheck/test/opf/Excessive_Spine_Items_epub3_fixed_format.epub",
     "filename" : "Excessive_Spine_Items_epub3_fixed_format.epub",
-    "checkerVersion" : "4.0.0-alpha11-SNAPSHOT",
-    "checkDate" : "09-05-2014 03:15:46",
-    "elapsedTime" : 802,
+    "checkerVersion" : "4.0.3-SNAPSHOT",
+    "checkDate" : "12-31-2016 01:12:03",
+    "elapsedTime" : 359,
     "nFatal" : 0,
     "nError" : 1,
     "nWarning" : 0,
@@ -2493,7 +2493,7 @@
     "message" : "Navigation Document has no 'landmarks nav' element.",
     "additionalLocations" : 0,
     "locations" : [ {
-      "path" : "Excessive_Spine_Items_epub3_fixed_format.epub",
+      "path" : "OPS/toc.xhtml",
       "line" : -1,
       "column" : -1,
       "context" : null

--- a/src/test/resources/com/adobe/epubcheck/test/opf/Excessive_Spine_Items_epub3_fixed_format_properties_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/opf/Excessive_Spine_Items_epub3_fixed_format_properties_expected_results.json
@@ -3,9 +3,9 @@
   "checker" : {
     "path" : "./com/adobe/epubcheck/test/opf/Excessive_Spine_Items_epub3_fixed_format_properties.epub",
     "filename" : "Excessive_Spine_Items_epub3_fixed_format_properties.epub",
-    "checkerVersion" : "4.0.0-alpha11-SNAPSHOT",
-    "checkDate" : "09-05-2014 03:15:47",
-    "elapsedTime" : 768,
+    "checkerVersion" : "4.0.3-SNAPSHOT",
+    "checkDate" : "12-31-2016 01:12:04",
+    "elapsedTime" : 322,
     "nFatal" : 0,
     "nError" : 1,
     "nWarning" : 0,
@@ -2493,7 +2493,7 @@
     "message" : "Navigation Document has no 'landmarks nav' element.",
     "additionalLocations" : 0,
     "locations" : [ {
-      "path" : "Excessive_Spine_Items_epub3_fixed_format_properties.epub",
+      "path" : "OPS/toc.xhtml",
       "line" : -1,
       "column" : -1,
       "context" : null

--- a/src/test/resources/com/adobe/epubcheck/test/opf/Fallbacks_epub3_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/opf/Fallbacks_epub3_expected_results.json
@@ -3,9 +3,9 @@
   "checker" : {
     "path" : "./com/adobe/epubcheck/test/opf/Fallbacks_epub3.epub",
     "filename" : "Fallbacks_epub3.epub",
-    "checkerVersion" : "4.0.0-alpha11-SNAPSHOT",
-    "checkDate" : "09-05-2014 03:15:52",
-    "elapsedTime" : 154,
+    "checkerVersion" : "4.0.3-SNAPSHOT",
+    "checkDate" : "12-31-2016 01:12:05",
+    "elapsedTime" : 22,
     "nFatal" : 0,
     "nError" : 1,
     "nWarning" : 0,
@@ -239,7 +239,7 @@
     "message" : "Navigation Document has no 'landmarks nav' element.",
     "additionalLocations" : 0,
     "locations" : [ {
-      "path" : "Fallbacks_epub3.epub",
+      "path" : "OPS/toc.xhtml",
       "line" : -1,
       "column" : -1,
       "context" : null

--- a/src/test/resources/com/adobe/epubcheck/test/opf/Media-type_handler_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/opf/Media-type_handler_expected_results.json
@@ -1,11 +1,11 @@
 {
   "customMessageFileName" : null,
   "checker" : {
-    "path" : "./target/test-classes/com/adobe/epubcheck/test/opf/Media-type_handler.epub",
+    "path" : "./com/adobe/epubcheck/test/opf/Media-type_handler.epub",
     "filename" : "Media-type_handler.epub",
-    "checkerVersion" : "4.0.0-alpha12-SNAPSHOT",
-    "checkDate" : "03-25-2015 10:06:15",
-    "elapsedTime" : 313,
+    "checkerVersion" : "4.0.3-SNAPSHOT",
+    "checkDate" : "12-31-2016 01:12:04",
+    "elapsedTime" : 144,
     "nFatal" : 0,
     "nError" : 5,
     "nWarning" : 0,
@@ -447,7 +447,7 @@
     "message" : "Navigation Document has no 'landmarks nav' element.",
     "additionalLocations" : 0,
     "locations" : [ {
-      "path" : "Media-type_handler.epub",
+      "path" : "OPS/toc.xhtml",
       "line" : -1,
       "column" : -1,
       "context" : null

--- a/src/test/resources/com/adobe/epubcheck/test/opf/Mismatched_mimetypes_epub3_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/opf/Mismatched_mimetypes_epub3_expected_results.json
@@ -4,8 +4,8 @@
     "path" : "./com/adobe/epubcheck/test/opf/Mismatched_mimetypes_epub3.epub",
     "filename" : "Mismatched_mimetypes_epub3.epub",
     "checkerVersion" : "4.0.3-SNAPSHOT",
-    "checkDate" : "12-18-2016 17:28:21",
-    "elapsedTime" : 83,
+    "checkDate" : "12-31-2016 01:12:04",
+    "elapsedTime" : 56,
     "nFatal" : 0,
     "nError" : 6,
     "nWarning" : 0,
@@ -278,7 +278,7 @@
     "message" : "Navigation Document has no 'landmarks nav' element.",
     "additionalLocations" : 0,
     "locations" : [ {
-      "path" : "Mismatched_mimetypes_epub3.epub",
+      "path" : "OPS/toc.xhtml",
       "line" : -1,
       "column" : -1,
       "context" : null

--- a/src/test/resources/com/adobe/epubcheck/test/opf/Missing_NAV_epub3_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/opf/Missing_NAV_epub3_expected_results.json
@@ -3,13 +3,13 @@
   "checker" : {
     "path" : "./com/adobe/epubcheck/test/opf/Missing_NAV_epub3.epub",
     "filename" : "Missing_NAV_epub3.epub",
-    "checkerVersion" : "4.0.0-alpha11-SNAPSHOT",
-    "checkDate" : "09-05-2014 03:15:40",
-    "elapsedTime" : 460,
+    "checkerVersion" : "4.0.3-SNAPSHOT",
+    "checkDate" : "12-31-2016 01:12:02",
+    "elapsedTime" : 21,
     "nFatal" : 0,
     "nError" : 1,
     "nWarning" : 0,
-    "nUsage" : 3
+    "nUsage" : 2
   },
   "publication" : {
     "publisher" : null,
@@ -157,18 +157,6 @@
     "additionalLocations" : 0,
     "locations" : [ {
       "path" : "OPS/page01.xhtml",
-      "line" : -1,
-      "column" : -1,
-      "context" : null
-    } ],
-    "suggestion" : null
-  }, {
-    "ID" : "ACC-008",
-    "severity" : "USAGE",
-    "message" : "Navigation Document has no 'landmarks nav' element.",
-    "additionalLocations" : 0,
-    "locations" : [ {
-      "path" : "Missing_NAV_epub3.epub",
       "line" : -1,
       "column" : -1,
       "context" : null

--- a/src/test/resources/com/adobe/epubcheck/test/opf/Missing_NCX_epub3_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/opf/Missing_NCX_epub3_expected_results.json
@@ -3,9 +3,9 @@
   "checker" : {
     "path" : "./com/adobe/epubcheck/test/opf/Missing_NCX_epub3.epub",
     "filename" : "Missing_NCX_epub3.epub",
-    "checkerVersion" : "4.0.0-alpha11-SNAPSHOT",
-    "checkDate" : "09-05-2014 03:15:41",
-    "elapsedTime" : 301,
+    "checkerVersion" : "4.0.3-SNAPSHOT",
+    "checkDate" : "12-31-2016 01:12:02",
+    "elapsedTime" : 22,
     "nFatal" : 0,
     "nError" : 0,
     "nWarning" : 0,
@@ -168,7 +168,7 @@
     "message" : "Navigation Document has no 'landmarks nav' element.",
     "additionalLocations" : 0,
     "locations" : [ {
-      "path" : "Missing_NCX_epub3.epub",
+      "path" : "OPS/toc.xhtml",
       "line" : -1,
       "column" : -1,
       "context" : null

--- a/src/test/resources/com/adobe/epubcheck/test/opf/Missing_Spine_epub3_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/opf/Missing_Spine_epub3_expected_results.json
@@ -3,9 +3,9 @@
   "checker" : {
     "path" : "./com/adobe/epubcheck/test/opf/Missing_Spine_epub3.epub",
     "filename" : "Missing_Spine_epub3.epub",
-    "checkerVersion" : "4.0.0-alpha11-SNAPSHOT",
-    "checkDate" : "09-05-2014 03:15:41",
-    "elapsedTime" : 284,
+    "checkerVersion" : "4.0.3-SNAPSHOT",
+    "checkDate" : "12-31-2016 01:12:02",
+    "elapsedTime" : 20,
     "nFatal" : 1,
     "nError" : 2,
     "nWarning" : 0,
@@ -168,7 +168,7 @@
     "message" : "Navigation Document has no 'landmarks nav' element.",
     "additionalLocations" : 0,
     "locations" : [ {
-      "path" : "Missing_Spine_epub3.epub",
+      "path" : "OPS/toc.xhtml",
       "line" : -1,
       "column" : -1,
       "context" : null

--- a/src/test/resources/com/adobe/epubcheck/test/opf/Missing_metadata_epub3_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/opf/Missing_metadata_epub3_expected_results.json
@@ -3,9 +3,9 @@
   "checker" : {
     "path" : "./com/adobe/epubcheck/test/opf/Missing_metadata_epub3.epub",
     "filename" : "Missing_metadata_epub3.epub",
-    "checkerVersion" : "4.0.0-alpha12-SNAPSHOT",
-    "checkDate" : "05-30-2015 00:41:52",
-    "elapsedTime" : 77,
+    "checkerVersion" : "4.0.3-SNAPSHOT",
+    "checkDate" : "12-31-2016 01:12:02",
+    "elapsedTime" : 31,
     "nFatal" : 0,
     "nError" : 3,
     "nWarning" : 0,
@@ -190,7 +190,7 @@
     "message" : "Navigation Document has no 'landmarks nav' element.",
     "additionalLocations" : 0,
     "locations" : [ {
-      "path" : "Missing_metadata_epub3.epub",
+      "path" : "OPS/toc.xhtml",
       "line" : -1,
       "column" : -1,
       "context" : null

--- a/src/test/resources/com/adobe/epubcheck/test/opf/Missing_unique_id_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/opf/Missing_unique_id_expected_results.json
@@ -3,9 +3,9 @@
   "checker" : {
     "path" : "./com/adobe/epubcheck/test/opf/Missing_unique_id.epub",
     "filename" : "Missing_unique_id.epub",
-    "checkerVersion" : "4.0.0-alpha11-SNAPSHOT",
-    "checkDate" : "09-05-2014 03:15:53",
-    "elapsedTime" : 139,
+    "checkerVersion" : "4.0.3-SNAPSHOT",
+    "checkDate" : "12-31-2016 01:12:05",
+    "elapsedTime" : 23,
     "nFatal" : 0,
     "nError" : 3,
     "nWarning" : 0,
@@ -190,7 +190,7 @@
     "message" : "Navigation Document has no 'landmarks nav' element.",
     "additionalLocations" : 0,
     "locations" : [ {
-      "path" : "Missing_unique_id.epub",
+      "path" : "OPS/toc.xhtml",
       "line" : -1,
       "column" : -1,
       "context" : null

--- a/src/test/resources/com/adobe/epubcheck/test/opf/Properties_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/opf/Properties_expected_results.json
@@ -3,9 +3,9 @@
   "checker" : {
     "path" : "./com/adobe/epubcheck/test/opf/Properties.epub",
     "filename" : "Properties.epub",
-    "checkerVersion" : "4.0.0-alpha11-SNAPSHOT",
-    "checkDate" : "09-05-2014 03:15:48",
-    "elapsedTime" : 169,
+    "checkerVersion" : "4.0.3-SNAPSHOT",
+    "checkDate" : "12-31-2016 01:12:05",
+    "elapsedTime" : 33,
     "nFatal" : 0,
     "nError" : 6,
     "nWarning" : 0,
@@ -271,7 +271,7 @@
     "message" : "Navigation Document has no 'landmarks nav' element.",
     "additionalLocations" : 0,
     "locations" : [ {
-      "path" : "Properties.epub",
+      "path" : "OPS/toc.xhtml",
       "line" : -1,
       "column" : -1,
       "context" : null

--- a/src/test/resources/com/adobe/epubcheck/test/opf/Publication_Metadata_epub3_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/opf/Publication_Metadata_epub3_expected_results.json
@@ -3,9 +3,9 @@
   "checker" : {
     "path" : "./com/adobe/epubcheck/test/opf/Publication_Metadata_epub3.epub",
     "filename" : "Publication_Metadata_epub3.epub",
-    "checkerVersion" : "4.0.0-alpha11-SNAPSHOT",
-    "checkDate" : "09-05-2014 03:15:47",
-    "elapsedTime" : 147,
+    "checkerVersion" : "4.0.3-SNAPSHOT",
+    "checkDate" : "12-31-2016 01:12:04",
+    "elapsedTime" : 22,
     "nFatal" : 0,
     "nError" : 0,
     "nWarning" : 0,
@@ -190,7 +190,7 @@
     "message" : "Navigation Document has no 'landmarks nav' element.",
     "additionalLocations" : 0,
     "locations" : [ {
-      "path" : "Publication_Metadata_epub3.epub",
+      "path" : "OPS/toc.xhtml",
       "line" : -1,
       "column" : -1,
       "context" : null

--- a/src/test/resources/com/adobe/epubcheck/test/opf/Publication_Metadata_epub3_expected_results.xml
+++ b/src/test/resources/com/adobe/epubcheck/test/opf/Publication_Metadata_epub3_expected_results.xml
@@ -1,16 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jhove xmlns="http://hul.harvard.edu/ois/xml/ns/jhove" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="epubcheck" release="4.0.0-alpha11-SNAPSHOT" date="2012-10-31">
- <date>2014-09-05T03:15:48+02:00</date>
+<jhove xmlns="http://hul.harvard.edu/ois/xml/ns/jhove"
+       date="2016-12-28"
+       name="epubcheck"
+       release="4.0.3-SNAPSHOT">
+ <date>2016-12-31T01:12:04+01:00</date>
  <repInfo uri="Publication_Metadata_epub3.epub">
-  <created>2014-09-05T01:49:14Z</created>
+  <created>2016-12-31T01:11:26Z</created>
   <lastModified>2013-01-30T12:00:00Z</lastModified>
   <format>application/epub+zip</format>
   <version>3.0.1</version>
   <status>Well-formed</status>
   <messages>
     <message severity="info" subMessage="ACC-007">ACC-007, HINT, [Content Documents do not use 'epub:type' attributes for semantic inflection.], OPS/page01.xhtml</message>
+    <message severity="info" subMessage="ACC-008">ACC-008, HINT, [Navigation Document has no 'landmarks nav' element.], OPS/toc.xhtml</message>
     <message severity="info" subMessage="HTM-010">HTM-010, HINT, [Namespace uri 'http://www.daisy.org/z3986/2005/ncx/' was found.], OPS/toc.ncx (2-68)</message>
-    <message severity="info" subMessage="ACC-008">ACC-008, HINT, [Navigation Document has no 'landmarks nav' element.], Publication_Metadata_epub3.epub</message>
   </messages>
   <mimeType>application/epub+zip</mimeType>
   <properties>
@@ -38,7 +41,7 @@
      <property>
       <name>CreationDate</name>
       <values arity="Scalar" type="Date">
-       <value>2014-09-05T01:49:14Z</value>
+       <value>2016-12-31T01:11:26Z</value>
       </values>
      </property>
      <property>

--- a/src/test/resources/com/adobe/epubcheck/test/opf/rendition_valid_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/opf/rendition_valid_expected_results.json
@@ -3,9 +3,9 @@
   "checker" : {
     "path" : "./com/adobe/epubcheck/test/opf/rendition_valid.epub",
     "filename" : "rendition_valid.epub",
-    "checkerVersion" : "4.0.0-alpha11-SNAPSHOT",
-    "checkDate" : "09-05-2014 03:15:43",
-    "elapsedTime" : 255,
+    "checkerVersion" : "4.0.3-SNAPSHOT",
+    "checkDate" : "12-31-2016 01:12:02",
+    "elapsedTime" : 43,
     "nFatal" : 0,
     "nError" : 1,
     "nWarning" : 0,
@@ -244,7 +244,7 @@
     "message" : "Navigation Document has no 'landmarks nav' element.",
     "additionalLocations" : 0,
     "locations" : [ {
-      "path" : "rendition_valid.epub",
+      "path" : "OPS/toc.xhtml",
       "line" : -1,
       "column" : -1,
       "context" : null

--- a/src/test/resources/com/adobe/epubcheck/test/opf/viewport2_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/opf/viewport2_expected_results.json
@@ -1,11 +1,11 @@
 {
   "customMessageFileName" : null,
   "checker" : {
-    "path" : "./target/test-classes/com/adobe/epubcheck/test/opf/viewport2.epub",
+    "path" : "./com/adobe/epubcheck/test/opf/viewport2.epub",
     "filename" : "viewport2.epub",
-    "checkerVersion" : "4.0.0-alpha12-SNAPSHOT",
-    "checkDate" : "03-25-2015 10:19:17",
-    "elapsedTime" : 90,
+    "checkerVersion" : "4.0.3-SNAPSHOT",
+    "checkDate" : "12-31-2016 01:12:02",
+    "elapsedTime" : 41,
     "nFatal" : 0,
     "nError" : 2,
     "nWarning" : 0,
@@ -271,7 +271,7 @@
     "message" : "Navigation Document has no 'landmarks nav' element.",
     "additionalLocations" : 0,
     "locations" : [ {
-      "path" : "viewport2.epub",
+      "path" : "OPS/toc.xhtml",
       "line" : -1,
       "column" : -1,
       "context" : null

--- a/src/test/resources/com/adobe/epubcheck/test/opf/viewport_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/opf/viewport_expected_results.json
@@ -1,11 +1,11 @@
 {
   "customMessageFileName" : null,
   "checker" : {
-    "path" : "./target/test-classes/com/adobe/epubcheck/test/opf/viewport.epub",
+    "path" : "./com/adobe/epubcheck/test/opf/viewport.epub",
     "filename" : "viewport.epub",
-    "checkerVersion" : "4.0.0-alpha12-SNAPSHOT",
-    "checkDate" : "03-25-2015 00:26:05",
-    "elapsedTime" : 2259,
+    "checkerVersion" : "4.0.3-SNAPSHOT",
+    "checkDate" : "12-31-2016 01:12:02",
+    "elapsedTime" : 57,
     "nFatal" : 0,
     "nError" : 3,
     "nWarning" : 0,
@@ -406,7 +406,7 @@
     "message" : "Navigation Document has no 'landmarks nav' element.",
     "additionalLocations" : 0,
     "locations" : [ {
-      "path" : "viewport.epub",
+      "path" : "OPS/toc.xhtml",
       "line" : -1,
       "column" : -1,
       "context" : null

--- a/src/test/resources/com/adobe/epubcheck/test/package/image_types_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/package/image_types_expected_results.json
@@ -1,11 +1,11 @@
 {
   "customMessageFileName" : null,
   "checker" : {
-    "path" : "./target/test-classes/com/adobe/epubcheck/test/package/image_types.epub",
+    "path" : "./com/adobe/epubcheck/test/package/image_types.epub",
     "filename" : "image_types.epub",
-    "checkerVersion" : "4.0.0-alpha12-SNAPSHOT",
-    "checkDate" : "03-25-2015 10:06:21",
-    "elapsedTime" : 653,
+    "checkerVersion" : "4.0.3-SNAPSHOT",
+    "checkDate" : "12-31-2016 01:12:05",
+    "elapsedTime" : 907,
     "nFatal" : 0,
     "nError" : 0,
     "nWarning" : 1,
@@ -300,7 +300,7 @@
     "message" : "Navigation Document has no 'landmarks nav' element.",
     "additionalLocations" : 0,
     "locations" : [ {
-      "path" : "image_types.epub",
+      "path" : "OPS/toc.xhtml",
       "line" : -1,
       "column" : -1,
       "context" : null

--- a/src/test/resources/com/adobe/epubcheck/test/package/interesting_paths_epub3_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/package/interesting_paths_epub3_expected_results.json
@@ -3,9 +3,9 @@
   "checker" : {
     "path" : "./com/adobe/epubcheck/test/package/interesting_paths_epub3.epub",
     "filename" : "interesting_paths_epub3.epub",
-    "checkerVersion" : "4.0.0-alpha11-SNAPSHOT",
-    "checkDate" : "09-05-2014 03:15:56",
-    "elapsedTime" : 125,
+    "checkerVersion" : "4.0.3-SNAPSHOT",
+    "checkDate" : "12-31-2016 01:12:05",
+    "elapsedTime" : 33,
     "nFatal" : 0,
     "nError" : 4,
     "nWarning" : 3,
@@ -310,7 +310,7 @@
     "message" : "Navigation Document has no 'landmarks nav' element.",
     "additionalLocations" : 0,
     "locations" : [ {
-      "path" : "interesting_paths_epub3.epub",
+      "path" : "OPS Content/toc.xhtml",
       "line" : -1,
       "column" : -1,
       "context" : null

--- a/src/test/resources/com/adobe/epubcheck/test/package/interesting_paths_epub3_expected_results.xml
+++ b/src/test/resources/com/adobe/epubcheck/test/package/interesting_paths_epub3_expected_results.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jhove xmlns="http://hul.harvard.edu/ois/xml/ns/jhove" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="epubcheck" release="4.0.0-alpha11-SNAPSHOT" date="2012-10-31">
- <date>2014-09-05T03:15:56+02:00</date>
+<jhove xmlns="http://hul.harvard.edu/ois/xml/ns/jhove"
+       date="2016-12-28"
+       name="epubcheck"
+       release="4.0.3-SNAPSHOT">
+ <date>2016-12-31T01:12:05+01:00</date>
  <repInfo uri="interesting_paths_epub3.epub">
-  <created>2014-09-05T01:49:14Z</created>
+  <created>2016-12-31T01:11:26Z</created>
   <lastModified>2012-10-10T12:00:00Z</lastModified>
   <format>application/epub+zip</format>
   <version>3.0.1</version>
@@ -10,7 +13,7 @@
   <messages>
     <message severity="error" subMessage="RSC-001">RSC-001, ERROR, [File 'OPS Content/Cyrillic_phi.html' could not be found.], interesting_paths_epub3.epub</message>
     <message severity="error" subMessage="RSC-001">RSC-001, ERROR, [File 'OPS Content/style.' could not be found.], interesting_paths_epub3.epub</message>
-    <message severity="error" subMessage="RSC-007">RSC-007, ERROR, [Referenced resource 'OPS Content/Cyrillic_phi.html' could not be found in the EPUB.], OPS Content/More XHTML Content/page01.xhtml (13-35)</message>
+    <message severity="error" subMessage="RSC-007">RSC-007, ERROR, [Referenced resource 'OPS Content/Cyrillic_Ф.xhtml' could not be found in the EPUB.], OPS Content/More XHTML Content/page01.xhtml (13-35)</message>
     <message severity="error" subMessage="PKG-009">PKG-009, ERROR, [File name contains characters that are not allowed in OCF file names: '"{","}"'.], OPS Content/page{03}.xhtml</message>
     <message severity="error" subMessage="HTM-014a">HTM-014a, WARN, [XHTML Content Document file name 'OPS Content/Cyrillic_phi.html' should have the extension '.xhtml'.], OPS Content/content.opf (14-86)</message>
     <message severity="error" subMessage="OPF-003">OPF-003, WARN, [Item 'OPS Content/Cyrillic_phi.xhtml' exists in the EPUB, but is not declared in the OPF manifest.], interesting_paths_epub3.epub</message>
@@ -24,13 +27,13 @@
     <message severity="info" subMessage="ACC-007">ACC-007, HINT, [Content Documents do not use 'epub:type' attributes for semantic inflection.], OPS Content/More XHTML Content/page01.xhtml</message>
     <message severity="info" subMessage="ACC-007">ACC-007, HINT, [Content Documents do not use 'epub:type' attributes for semantic inflection.], XHTML Content/page 02.xhtml</message>
     <message severity="info" subMessage="ACC-007">ACC-007, HINT, [Content Documents do not use 'epub:type' attributes for semantic inflection.], OPS Content/page{03}.xhtml</message>
+    <message severity="info" subMessage="ACC-008">ACC-008, HINT, [Navigation Document has no 'landmarks nav' element.], OPS Content/toc.xhtml</message>
     <message severity="info" subMessage="OPF-058">OPF-058, HINT, [Spine item has no TOC entry reference.], OPS Content/toc.xhtml</message>
     <message severity="info" subMessage="OPF-058">OPF-058, HINT, [Spine item has no TOC entry reference.], OPS Content/toc.xhtml</message>
     <message severity="info" subMessage="HTM-010">HTM-010, HINT, [Namespace uri 'http://www.daisy.org/z3986/2005/ncx/' was found.], OPS Content/toc.ncx (2-68)</message>
     <message severity="info" subMessage="OPF-059">OPF-059, HINT, [Spine item has no NCX entry reference.], OPS Content/toc.ncx</message>
     <message severity="info" subMessage="OPF-059">OPF-059, HINT, [Spine item has no NCX entry reference.], OPS Content/toc.ncx</message>
-    <message severity="info" subMessage="ACC-008">ACC-008, HINT, [Navigation Document has no 'landmarks nav' element.], interesting_paths_epub3.epub</message>
-  </messages>
+    </messages>
   <mimeType>application/epub+zip</mimeType>
   <properties>
    <property>
@@ -57,7 +60,7 @@
      <property>
       <name>CreationDate</name>
       <values arity="Scalar" type="Date">
-       <value>2014-09-05T01:49:14Z</value>
+       <value>2016-12-31T01:11:26Z</value>
       </values>
      </property>
      <property>

--- a/src/test/resources/com/adobe/epubcheck/test/package/missing_mimetype_file_epub3_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/package/missing_mimetype_file_epub3_expected_results.json
@@ -3,9 +3,9 @@
   "checker" : {
     "path" : "./com/adobe/epubcheck/test/package/missing_mimetype_file_epub3.epub",
     "filename" : "missing_mimetype_file_epub3.epub",
-    "checkerVersion" : "4.0.0-alpha11-SNAPSHOT",
-    "checkDate" : "09-05-2014 03:15:56",
-    "elapsedTime" : 119,
+    "checkerVersion" : "4.0.3-SNAPSHOT",
+    "checkDate" : "12-31-2016 01:12:05",
+    "elapsedTime" : 29,
     "nFatal" : 0,
     "nError" : 1,
     "nWarning" : 0,
@@ -168,7 +168,7 @@
     "message" : "Navigation Document has no 'landmarks nav' element.",
     "additionalLocations" : 0,
     "locations" : [ {
-      "path" : "missing_mimetype_file_epub3.epub",
+      "path" : "OPS/toc.xhtml",
       "line" : -1,
       "column" : -1,
       "context" : null

--- a/src/test/resources/com/adobe/epubcheck/test/package/missing_opf_file_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/package/missing_opf_file_expected_results.json
@@ -3,9 +3,9 @@
   "checker" : {
     "path" : "./com/adobe/epubcheck/test/package/missing_opf_file.epub",
     "filename" : "missing_opf_file.epub",
-    "checkerVersion" : "4.0.0-alpha11-SNAPSHOT",
-    "checkDate" : "09-05-2014 03:15:56",
-    "elapsedTime" : 17,
+    "checkerVersion" : "4.0.3-SNAPSHOT",
+    "checkDate" : "12-31-2016 01:12:05",
+    "elapsedTime" : 12,
     "nFatal" : 1,
     "nError" : 1,
     "nWarning" : 0,
@@ -112,7 +112,7 @@
     "message" : "Navigation Document has no 'landmarks nav' element.",
     "additionalLocations" : 0,
     "locations" : [ {
-      "path" : "missing_opf_file.epub",
+      "path" : "OPS/toc.xhtml",
       "line" : -1,
       "column" : -1,
       "context" : null

--- a/src/test/resources/com/adobe/epubcheck/test/package/missing_toc_file_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/package/missing_toc_file_expected_results.json
@@ -3,13 +3,13 @@
   "checker" : {
     "path" : "./com/adobe/epubcheck/test/package/missing_toc_file.epub",
     "filename" : "missing_toc_file.epub",
-    "checkerVersion" : "4.0.0-alpha11-SNAPSHOT",
-    "checkDate" : "09-05-2014 03:15:55",
-    "elapsedTime" : 105,
+    "checkerVersion" : "4.0.3-SNAPSHOT",
+    "checkDate" : "12-31-2016 01:12:05",
+    "elapsedTime" : 20,
     "nFatal" : 0,
     "nError" : 1,
     "nWarning" : 0,
-    "nUsage" : 3
+    "nUsage" : 2
   },
   "publication" : {
     "publisher" : null,
@@ -179,18 +179,6 @@
     "additionalLocations" : 0,
     "locations" : [ {
       "path" : "OPS/page01.xhtml",
-      "line" : -1,
-      "column" : -1,
-      "context" : null
-    } ],
-    "suggestion" : null
-  }, {
-    "ID" : "ACC-008",
-    "severity" : "USAGE",
-    "message" : "Navigation Document has no 'landmarks nav' element.",
-    "additionalLocations" : 0,
-    "locations" : [ {
-      "path" : "missing_toc_file.epub",
       "line" : -1,
       "column" : -1,
       "context" : null

--- a/src/test/resources/com/adobe/epubcheck/test/package/path_resolution_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/package/path_resolution_expected_results.json
@@ -1,11 +1,11 @@
 {
   "customMessageFileName" : null,
   "checker" : {
-    "path" : "./target/test-classes/com/adobe/epubcheck/test/package/path_resolution.epub",
+    "path" : "./com/adobe/epubcheck/test/package/path_resolution.epub",
     "filename" : "path_resolution.epub",
-    "checkerVersion" : "4.0.0-alpha12-SNAPSHOT",
-    "checkDate" : "03-25-2015 10:19:29",
-    "elapsedTime" : 196,
+    "checkerVersion" : "4.0.3-SNAPSHOT",
+    "checkDate" : "12-31-2016 01:12:06",
+    "elapsedTime" : 220,
     "nFatal" : 0,
     "nError" : 0,
     "nWarning" : 0,
@@ -359,7 +359,7 @@
     "message" : "Navigation Document has no 'landmarks nav' element.",
     "additionalLocations" : 0,
     "locations" : [ {
-      "path" : "path_resolution.epub",
+      "path" : "OPS/toc.xhtml",
       "line" : -1,
       "column" : -1,
       "context" : null

--- a/src/test/resources/com/adobe/epubcheck/test/scripts/XMLHttpRequest_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/scripts/XMLHttpRequest_expected_results.json
@@ -3,9 +3,9 @@
   "checker" : {
     "path" : "./com/adobe/epubcheck/test/scripts/XMLHttpRequest.epub",
     "filename" : "XMLHttpRequest.epub",
-    "checkerVersion" : "4.0.0-alpha11-SNAPSHOT",
-    "checkDate" : "09-05-2014 03:16:20",
-    "elapsedTime" : 93,
+    "checkerVersion" : "4.0.3-SNAPSHOT",
+    "checkDate" : "12-31-2016 01:12:06",
+    "elapsedTime" : 30,
     "nFatal" : 0,
     "nError" : 0,
     "nWarning" : 0,
@@ -288,7 +288,7 @@
     "message" : "Navigation Document has no 'landmarks nav' element.",
     "additionalLocations" : 0,
     "locations" : [ {
-      "path" : "XMLHttpRequest.epub",
+      "path" : "OPS/toc.xhtml",
       "line" : -1,
       "column" : -1,
       "context" : null

--- a/src/test/resources/com/adobe/epubcheck/test/scripts/eval_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/scripts/eval_expected_results.json
@@ -3,9 +3,9 @@
   "checker" : {
     "path" : "./com/adobe/epubcheck/test/scripts/eval.epub",
     "filename" : "eval.epub",
-    "checkerVersion" : "4.0.0-alpha11-SNAPSHOT",
-    "checkDate" : "09-05-2014 03:16:20",
-    "elapsedTime" : 100,
+    "checkerVersion" : "4.0.3-SNAPSHOT",
+    "checkDate" : "12-31-2016 01:12:06",
+    "elapsedTime" : 32,
     "nFatal" : 0,
     "nError" : 0,
     "nWarning" : 0,
@@ -266,7 +266,7 @@
     "message" : "Navigation Document has no 'landmarks nav' element.",
     "additionalLocations" : 0,
     "locations" : [ {
-      "path" : "eval.epub",
+      "path" : "OPS/toc.xhtml",
       "line" : -1,
       "column" : -1,
       "context" : null

--- a/src/test/resources/com/adobe/epubcheck/test/scripts/properties_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/scripts/properties_expected_results.json
@@ -3,9 +3,9 @@
   "checker" : {
     "path" : "./com/adobe/epubcheck/test/scripts/properties.epub",
     "filename" : "properties.epub",
-    "checkerVersion" : "4.0.0-alpha11-SNAPSHOT",
-    "checkDate" : "09-05-2014 03:16:19",
-    "elapsedTime" : 138,
+    "checkerVersion" : "4.0.3-SNAPSHOT",
+    "checkDate" : "12-31-2016 01:12:06",
+    "elapsedTime" : 47,
     "nFatal" : 0,
     "nError" : 3,
     "nWarning" : 0,
@@ -359,7 +359,7 @@
     "message" : "Navigation Document has no 'landmarks nav' element.",
     "additionalLocations" : 0,
     "locations" : [ {
-      "path" : "properties.epub",
+      "path" : "OPS/toc.xhtml",
       "line" : -1,
       "column" : -1,
       "context" : null

--- a/src/test/resources/com/adobe/epubcheck/test/scripts/storage_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/scripts/storage_expected_results.json
@@ -3,9 +3,9 @@
   "checker" : {
     "path" : "./com/adobe/epubcheck/test/scripts/storage.epub",
     "filename" : "storage.epub",
-    "checkerVersion" : "4.0.0-alpha11-SNAPSHOT",
-    "checkDate" : "09-05-2014 03:16:20",
-    "elapsedTime" : 100,
+    "checkerVersion" : "4.0.3-SNAPSHOT",
+    "checkDate" : "12-31-2016 01:12:06",
+    "elapsedTime" : 29,
     "nFatal" : 0,
     "nError" : 0,
     "nWarning" : 0,
@@ -266,7 +266,7 @@
     "message" : "Navigation Document has no 'landmarks nav' element.",
     "additionalLocations" : 0,
     "locations" : [ {
-      "path" : "storage.epub",
+      "path" : "OPS/toc.xhtml",
       "line" : -1,
       "column" : -1,
       "context" : null

--- a/src/test/resources/com/adobe/epubcheck/test/scripts/unused_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/scripts/unused_expected_results.json
@@ -1,11 +1,11 @@
 {
   "customMessageFileName" : null,
   "checker" : {
-    "path" : "./target/test-classes/com/adobe/epubcheck/test/scripts/unused.epub",
+    "path" : "./com/adobe/epubcheck/test/scripts/unused.epub",
     "filename" : "unused.epub",
-    "checkerVersion" : "4.0.0-alpha12-SNAPSHOT",
-    "checkDate" : "03-25-2015 10:06:34",
-    "elapsedTime" : 50,
+    "checkerVersion" : "4.0.3-SNAPSHOT",
+    "checkDate" : "12-31-2016 01:12:06",
+    "elapsedTime" : 39,
     "nFatal" : 0,
     "nError" : 0,
     "nWarning" : 0,
@@ -288,7 +288,7 @@
     "message" : "Navigation Document has no 'landmarks nav' element.",
     "additionalLocations" : 0,
     "locations" : [ {
-      "path" : "unused.epub",
+      "path" : "OPS/toc.xhtml",
       "line" : -1,
       "column" : -1,
       "context" : null

--- a/src/test/resources/com/adobe/epubcheck/test/toc/fragments_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/toc/fragments_expected_results.json
@@ -1,11 +1,11 @@
 {
   "customMessageFileName" : null,
   "checker" : {
-    "path" : "./target/test-classes/com/adobe/epubcheck/test/toc/fragments.epub",
+    "path" : "./com/adobe/epubcheck/test/toc/fragments.epub",
     "filename" : "fragments.epub",
-    "checkerVersion" : "4.0.0-alpha12-SNAPSHOT",
-    "checkDate" : "03-25-2015 10:06:36",
-    "elapsedTime" : 46,
+    "checkerVersion" : "4.0.3-SNAPSHOT",
+    "checkDate" : "12-31-2016 01:12:07",
+    "elapsedTime" : 28,
     "nFatal" : 0,
     "nError" : 0,
     "nWarning" : 0,
@@ -217,7 +217,7 @@
     "message" : "Navigation Document has no 'landmarks nav' element.",
     "additionalLocations" : 0,
     "locations" : [ {
-      "path" : "fragments.epub",
+      "path" : "OPS/toc.xhtml",
       "line" : -1,
       "column" : -1,
       "context" : null

--- a/src/test/resources/com/adobe/epubcheck/test/toc/invalid_ncx_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/toc/invalid_ncx_expected_results.json
@@ -1,11 +1,11 @@
 {
   "customMessageFileName" : null,
   "checker" : {
-    "path" : "./target/test-classes/com/adobe/epubcheck/test/toc/invalid_ncx.epub",
+    "path" : "./com/adobe/epubcheck/test/toc/invalid_ncx.epub",
     "filename" : "invalid_ncx.epub",
-    "checkerVersion" : "4.0.0-alpha12-SNAPSHOT",
-    "checkDate" : "03-25-2015 10:06:36",
-    "elapsedTime" : 41,
+    "checkerVersion" : "4.0.3-SNAPSHOT",
+    "checkDate" : "12-31-2016 01:12:07",
+    "elapsedTime" : 24,
     "nFatal" : 0,
     "nError" : 4,
     "nWarning" : 0,
@@ -190,7 +190,7 @@
     "message" : "Navigation Document has no 'landmarks nav' element.",
     "additionalLocations" : 0,
     "locations" : [ {
-      "path" : "invalid_ncx.epub",
+      "path" : "OPS/toc.xhtml",
       "line" : -1,
       "column" : -1,
       "context" : null

--- a/src/test/resources/com/adobe/epubcheck/test/toc/missing_epub_type_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/toc/missing_epub_type_expected_results.json
@@ -3,9 +3,9 @@
   "checker" : {
     "path" : "./com/adobe/epubcheck/test/toc/missing_epub_type.epub",
     "filename" : "missing_epub_type.epub",
-    "checkerVersion" : "4.0.0-alpha11-SNAPSHOT",
-    "checkDate" : "09-05-2014 03:16:23",
-    "elapsedTime" : 85,
+    "checkerVersion" : "4.0.3-SNAPSHOT",
+    "checkDate" : "12-31-2016 01:12:07",
+    "elapsedTime" : 34,
     "nFatal" : 0,
     "nError" : 1,
     "nWarning" : 0,
@@ -195,7 +195,7 @@
     "message" : "Navigation Document has no 'landmarks nav' element.",
     "additionalLocations" : 0,
     "locations" : [ {
-      "path" : "missing_epub_type.epub",
+      "path" : "OPS/toc.xhtml",
       "line" : -1,
       "column" : -1,
       "context" : null

--- a/src/test/resources/com/adobe/epubcheck/test/xhtml/External_media_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/xhtml/External_media_expected_results.json
@@ -1,11 +1,11 @@
 {
   "customMessageFileName" : null,
   "checker" : {
-    "path" : "./target/test-classes/com/adobe/epubcheck/test/xhtml/External_media.epub",
+    "path" : "./com/adobe/epubcheck/test/xhtml/External_media.epub",
     "filename" : "External_media.epub",
-    "checkerVersion" : "4.0.0-alpha12-SNAPSHOT",
-    "checkDate" : "03-25-2015 10:06:39",
-    "elapsedTime" : 47,
+    "checkerVersion" : "4.0.3-SNAPSHOT",
+    "checkDate" : "12-31-2016 01:12:07",
+    "elapsedTime" : 53,
     "nFatal" : 0,
     "nError" : 0,
     "nWarning" : 0,
@@ -305,7 +305,7 @@
     "message" : "Navigation Document has no 'landmarks nav' element.",
     "additionalLocations" : 0,
     "locations" : [ {
-      "path" : "External_media.epub",
+      "path" : "OPS/toc.xhtml",
       "line" : -1,
       "column" : -1,
       "context" : null

--- a/src/test/resources/com/adobe/epubcheck/test/xhtml/accessibility_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/xhtml/accessibility_expected_results.json
@@ -3,9 +3,9 @@
   "checker" : {
     "path" : "./com/adobe/epubcheck/test/xhtml/accessibility.epub",
     "filename" : "accessibility.epub",
-    "checkerVersion" : "4.0.0-alpha11-SNAPSHOT",
-    "checkDate" : "09-05-2014 03:16:29",
-    "elapsedTime" : 140,
+    "checkerVersion" : "4.0.3-SNAPSHOT",
+    "checkDate" : "12-31-2016 01:12:08",
+    "elapsedTime" : 69,
     "nFatal" : 0,
     "nError" : 2,
     "nWarning" : 0,
@@ -288,7 +288,7 @@
     "message" : "Navigation Document has no 'landmarks nav' element.",
     "additionalLocations" : 0,
     "locations" : [ {
-      "path" : "accessibility.epub",
+      "path" : "OPS/toc.xhtml",
       "line" : -1,
       "column" : -1,
       "context" : null

--- a/src/test/resources/com/adobe/epubcheck/test/xhtml/dtd_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/xhtml/dtd_expected_results.json
@@ -1,11 +1,11 @@
 {
   "customMessageFileName" : null,
   "checker" : {
-    "path" : "./target/test-classes/com/adobe/epubcheck/test/xhtml/dtd.epub",
+    "path" : "./com/adobe/epubcheck/test/xhtml/dtd.epub",
     "filename" : "dtd.epub",
-    "checkerVersion" : "4.0.2-SNAPSHOT",
-    "checkDate" : "11-29-2016 13:57:01",
-    "elapsedTime" : 52,
+    "checkerVersion" : "4.0.3-SNAPSHOT",
+    "checkDate" : "12-31-2016 01:12:07",
+    "elapsedTime" : 64,
     "nFatal" : 0,
     "nError" : 6,
     "nWarning" : 2,
@@ -398,7 +398,7 @@
     "message" : "Navigation Document has no 'landmarks nav' element.",
     "additionalLocations" : 0,
     "locations" : [ {
-      "path" : "dtd.epub",
+      "path" : "OPS/toc.xhtml",
       "line" : -1,
       "column" : -1,
       "context" : null

--- a/src/test/resources/com/adobe/epubcheck/test/xhtml/epubcfi_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/xhtml/epubcfi_expected_results.json
@@ -3,9 +3,9 @@
   "checker" : {
     "path" : "./com/adobe/epubcheck/test/xhtml/epubcfi.epub",
     "filename" : "epubcfi.epub",
-    "checkerVersion" : "4.0.0-alpha11-SNAPSHOT",
-    "checkDate" : "09-05-2014 03:16:28",
-    "elapsedTime" : 82,
+    "checkerVersion" : "4.0.3-SNAPSHOT",
+    "checkDate" : "12-31-2016 01:12:07",
+    "elapsedTime" : 27,
     "nFatal" : 0,
     "nError" : 0,
     "nWarning" : 0,
@@ -217,7 +217,7 @@
     "message" : "Navigation Document has no 'landmarks nav' element.",
     "additionalLocations" : 0,
     "locations" : [ {
-      "path" : "epubcfi.epub",
+      "path" : "OPS/toc.xhtml",
       "line" : -1,
       "column" : -1,
       "context" : null

--- a/src/test/resources/com/adobe/epubcheck/test/xhtml/html5_deprecated_epub3_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/xhtml/html5_deprecated_epub3_expected_results.json
@@ -3,9 +3,9 @@
   "checker" : {
     "path" : "./com/adobe/epubcheck/test/xhtml/html5_deprecated_epub3.epub",
     "filename" : "html5_deprecated_epub3.epub",
-    "checkerVersion" : "4.0.0-alpha11-SNAPSHOT",
-    "checkDate" : "09-05-2014 03:16:27",
-    "elapsedTime" : 86,
+    "checkerVersion" : "4.0.3-SNAPSHOT",
+    "checkDate" : "12-31-2016 01:12:07",
+    "elapsedTime" : 30,
     "nFatal" : 0,
     "nError" : 4,
     "nWarning" : 0,
@@ -190,7 +190,7 @@
     "message" : "Navigation Document has no 'landmarks nav' element.",
     "additionalLocations" : 0,
     "locations" : [ {
-      "path" : "html5_deprecated_epub3.epub",
+      "path" : "OPS/toc.xhtml",
       "line" : -1,
       "column" : -1,
       "context" : null

--- a/src/test/resources/com/adobe/epubcheck/test/xhtml/html5_epub3_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/xhtml/html5_epub3_expected_results.json
@@ -3,9 +3,9 @@
   "checker" : {
     "path" : "./com/adobe/epubcheck/test/xhtml/html5_epub3.epub",
     "filename" : "html5_epub3.epub",
-    "checkerVersion" : "4.0.0-alpha11-SNAPSHOT",
-    "checkDate" : "09-05-2014 03:16:27",
-    "elapsedTime" : 81,
+    "checkerVersion" : "4.0.3-SNAPSHOT",
+    "checkDate" : "12-31-2016 01:12:07",
+    "elapsedTime" : 26,
     "nFatal" : 1,
     "nError" : 1,
     "nWarning" : 0,
@@ -234,7 +234,7 @@
     "message" : "Navigation Document has no 'landmarks nav' element.",
     "additionalLocations" : 0,
     "locations" : [ {
-      "path" : "html5_epub3.epub",
+      "path" : "OPS/toc.xhtml",
       "line" : -1,
       "column" : -1,
       "context" : null

--- a/src/test/resources/com/adobe/epubcheck/test/xhtml/hyperlinks_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/xhtml/hyperlinks_expected_results.json
@@ -1,11 +1,11 @@
 {
   "customMessageFileName" : null,
   "checker" : {
-    "path" : "./target/test-classes/com/adobe/epubcheck/test/xhtml/hyperlinks.epub",
+    "path" : "./com/adobe/epubcheck/test/xhtml/hyperlinks.epub",
     "filename" : "hyperlinks.epub",
-    "checkerVersion" : "4.0.0-alpha12-SNAPSHOT",
-    "checkDate" : "03-25-2015 10:06:39",
-    "elapsedTime" : 64,
+    "checkerVersion" : "4.0.3-SNAPSHOT",
+    "checkDate" : "12-31-2016 01:12:07",
+    "elapsedTime" : 177,
     "nFatal" : 0,
     "nError" : 7,
     "nWarning" : 2,
@@ -337,7 +337,7 @@
     "message" : "Navigation Document has no 'landmarks nav' element.",
     "additionalLocations" : 0,
     "locations" : [ {
-      "path" : "hyperlinks.epub",
+      "path" : "OPS/toc.xhtml",
       "line" : -1,
       "column" : -1,
       "context" : null

--- a/src/test/resources/com/adobe/epubcheck/test/xhtml/lang_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/xhtml/lang_expected_results.json
@@ -3,9 +3,9 @@
   "checker" : {
     "path" : "./com/adobe/epubcheck/test/xhtml/lang.epub",
     "filename" : "lang.epub",
-    "checkerVersion" : "4.0.0-alpha11-SNAPSHOT",
-    "checkDate" : "09-05-2014 03:16:28",
-    "elapsedTime" : 82,
+    "checkerVersion" : "4.0.3-SNAPSHOT",
+    "checkDate" : "12-31-2016 01:12:07",
+    "elapsedTime" : 38,
     "nFatal" : 0,
     "nError" : 2,
     "nWarning" : 0,
@@ -244,7 +244,7 @@
     "message" : "Navigation Document has no 'landmarks nav' element.",
     "additionalLocations" : 0,
     "locations" : [ {
-      "path" : "lang.epub",
+      "path" : "OPS/toc.xhtml",
       "line" : -1,
       "column" : -1,
       "context" : null

--- a/src/test/resources/com/adobe/epubcheck/test/xhtml/lorem_pagemaps1_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/xhtml/lorem_pagemaps1_expected_results.json
@@ -3,9 +3,9 @@
   "checker" : {
     "path" : "./com/adobe/epubcheck/test/xhtml/lorem_pagemaps1.epub",
     "filename" : "lorem_pagemaps1.epub",
-    "checkerVersion" : "4.0.0-alpha11-SNAPSHOT",
-    "checkDate" : "09-05-2014 03:16:29",
-    "elapsedTime" : 86,
+    "checkerVersion" : "4.0.3-SNAPSHOT",
+    "checkDate" : "12-31-2016 01:12:08",
+    "elapsedTime" : 28,
     "nFatal" : 0,
     "nError" : 1,
     "nWarning" : 0,
@@ -234,7 +234,7 @@
     "message" : "Navigation Document has no 'landmarks nav' element.",
     "additionalLocations" : 0,
     "locations" : [ {
-      "path" : "lorem_pagemaps1.epub",
+      "path" : "EPUB/nav.xhtml",
       "line" : -1,
       "column" : -1,
       "context" : null

--- a/src/test/resources/com/adobe/epubcheck/test/xhtml/lorem_pagemaps2_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/xhtml/lorem_pagemaps2_expected_results.json
@@ -3,9 +3,9 @@
   "checker" : {
     "path" : "./com/adobe/epubcheck/test/xhtml/lorem_pagemaps2.epub",
     "filename" : "lorem_pagemaps2.epub",
-    "checkerVersion" : "4.0.0-alpha11-SNAPSHOT",
-    "checkDate" : "09-05-2014 03:16:29",
-    "elapsedTime" : 87,
+    "checkerVersion" : "4.0.3-SNAPSHOT",
+    "checkDate" : "12-31-2016 01:12:08",
+    "elapsedTime" : 26,
     "nFatal" : 0,
     "nError" : 0,
     "nWarning" : 0,
@@ -200,7 +200,7 @@
     "message" : "Navigation Document has no 'landmarks nav' element.",
     "additionalLocations" : 0,
     "locations" : [ {
-      "path" : "lorem_pagemaps2.epub",
+      "path" : "EPUB/nav.xhtml",
       "line" : -1,
       "column" : -1,
       "context" : null

--- a/src/test/resources/com/adobe/epubcheck/test/xhtml/lorem_pagemaps3_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/xhtml/lorem_pagemaps3_expected_results.json
@@ -3,9 +3,9 @@
   "checker" : {
     "path" : "./com/adobe/epubcheck/test/xhtml/lorem_pagemaps3.epub",
     "filename" : "lorem_pagemaps3.epub",
-    "checkerVersion" : "4.0.0-alpha11-SNAPSHOT",
-    "checkDate" : "09-05-2014 03:16:29",
-    "elapsedTime" : 92,
+    "checkerVersion" : "4.0.3-SNAPSHOT",
+    "checkDate" : "12-31-2016 01:12:08",
+    "elapsedTime" : 22,
     "nFatal" : 0,
     "nError" : 1,
     "nWarning" : 2,
@@ -234,7 +234,7 @@
     "message" : "Navigation Document has no 'landmarks nav' element.",
     "additionalLocations" : 0,
     "locations" : [ {
-      "path" : "lorem_pagemaps3.epub",
+      "path" : "EPUB/nav.xhtml",
       "line" : -1,
       "column" : -1,
       "context" : null

--- a/src/test/resources/com/adobe/epubcheck/test/xhtml/media_overlays_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/xhtml/media_overlays_expected_results.json
@@ -1,11 +1,11 @@
 {
   "customMessageFileName" : null,
   "checker" : {
-    "path" : "./target/test-classes/com/adobe/epubcheck/test/xhtml/media_overlays.epub",
+    "path" : "./com/adobe/epubcheck/test/xhtml/media_overlays.epub",
     "filename" : "media_overlays.epub",
-    "checkerVersion" : "4.0.0-alpha12-SNAPSHOT",
-    "checkDate" : "03-25-2015 14:49:51",
-    "elapsedTime" : 3500,
+    "checkerVersion" : "4.0.3-SNAPSHOT",
+    "checkDate" : "12-31-2016 01:12:07",
+    "elapsedTime" : 660,
     "nFatal" : 0,
     "nError" : 3,
     "nWarning" : 0,
@@ -410,7 +410,7 @@
     "message" : "Navigation Document has no 'landmarks nav' element.",
     "additionalLocations" : 0,
     "locations" : [ {
-      "path" : "media_overlays.epub",
+      "path" : "OPS/toc.xhtml",
       "line" : -1,
       "column" : -1,
       "context" : null

--- a/src/test/resources/com/adobe/epubcheck/test/xhtml/namespaces_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/xhtml/namespaces_expected_results.json
@@ -3,9 +3,9 @@
   "checker" : {
     "path" : "./com/adobe/epubcheck/test/xhtml/namespaces.epub",
     "filename" : "namespaces.epub",
-    "checkerVersion" : "4.0.0-alpha11-SNAPSHOT",
-    "checkDate" : "09-05-2014 03:16:29",
-    "elapsedTime" : 75,
+    "checkerVersion" : "4.0.3-SNAPSHOT",
+    "checkDate" : "12-31-2016 01:12:08",
+    "elapsedTime" : 35,
     "nFatal" : 0,
     "nError" : 3,
     "nWarning" : 0,
@@ -190,7 +190,7 @@
     "message" : "Navigation Document has no 'landmarks nav' element.",
     "additionalLocations" : 0,
     "locations" : [ {
-      "path" : "namespaces.epub",
+      "path" : "OPS/toc.xhtml",
       "line" : -1,
       "column" : -1,
       "context" : null

--- a/src/test/resources/com/adobe/epubcheck/test/xhtml/nesting_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/xhtml/nesting_expected_results.json
@@ -3,9 +3,9 @@
   "checker" : {
     "path" : "./com/adobe/epubcheck/test/xhtml/nesting.epub",
     "filename" : "nesting.epub",
-    "checkerVersion" : "4.0.0-alpha11-SNAPSHOT",
-    "checkDate" : "09-05-2014 03:16:27",
-    "elapsedTime" : 88,
+    "checkerVersion" : "4.0.3-SNAPSHOT",
+    "checkDate" : "12-31-2016 01:12:07",
+    "elapsedTime" : 42,
     "nFatal" : 0,
     "nError" : 0,
     "nWarning" : 0,
@@ -239,7 +239,7 @@
     "message" : "Navigation Document has no 'landmarks nav' element.",
     "additionalLocations" : 0,
     "locations" : [ {
-      "path" : "nesting.epub",
+      "path" : "OPS/toc.xhtml",
       "line" : -1,
       "column" : -1,
       "context" : null


### PR DESCRIPTION
This is a bunch of commits to solve #457 and #734 (issues with `ACC-008` and landmarks in general).

I split this into 4 commits to make clearer what has been changed, but this can be squashed in the end...

There has been a typo "landmark" instead of "landmarks" and problems with retrieving attributes with namespaces.

Also moved the landmarks check from `ctc/EpubHTML5StructureCheck.java` to `ctc/EpubNavCheck.java` to be able to report the proper NAV file instead of an empty context.
This lead to the discovery of #734.

Fixed that and changed 73 test files for `ACC-008`.