### PR TITLE
[fix #655] display error/warning count in EpubCheck result

### DIFF
--- a/src/main/java/com/adobe/epubcheck/api/MasterReport.java
+++ b/src/main/java/com/adobe/epubcheck/api/MasterReport.java
@@ -19,7 +19,7 @@ import com.adobe.epubcheck.util.ReportingLevel;
 public abstract class MasterReport implements Report
 {
   public static Set<MessageId> allReportedMessageIds = new HashSet<MessageId>();
-  int errorCount, warningCount, fatalErrorCount, usageCount = 0;
+  int errorCount, warningCount, fatalErrorCount, usageCount, infoCount = 0;
   int reportingLevel = ReportingLevel.Info;
   private String ePubName;
   private MessageDictionary dictionary = new MessageDictionary(null, this);
@@ -71,6 +71,10 @@ public abstract class MasterReport implements Report
       else if (severity.equals(Severity.USAGE))
       {
         usageCount++;
+      }
+      else if (severity.equals(Severity.INFO))
+      {
+        infoCount++;
       }
       this.message(message, location, args);
     }
@@ -136,6 +140,18 @@ public abstract class MasterReport implements Report
   public int getFatalErrorCount()
   {
     return fatalErrorCount;
+  }
+
+  @Override
+  public int getInfoCount()
+  {
+    return infoCount;
+  }
+
+  @Override
+  public int getUsageCount()
+  {
+    return usageCount;
   }
 
   @Override

--- a/src/main/java/com/adobe/epubcheck/api/Report.java
+++ b/src/main/java/com/adobe/epubcheck/api/Report.java
@@ -70,6 +70,10 @@ public interface Report
 
   public int getFatalErrorCount();
 
+  public int getInfoCount();
+
+  public int getUsageCount();
+
   /**
    * Called to create a report after the checks have been made
    */

--- a/src/main/java/com/adobe/epubcheck/tool/EpubChecker.java
+++ b/src/main/java/com/adobe/epubcheck/tool/EpubChecker.java
@@ -236,12 +236,13 @@ public class EpubChecker
 
   public int run(String[] args)
   {
+    Report report = null;
     int returnValue = 1;
     try
     {
       if (processArguments(args))
       {
-        Report report = createReport();
+        report = createReport();
         report.initialize();
         if (listChecks)
         {
@@ -264,10 +265,38 @@ public class EpubChecker
       returnValue = 1;
     } finally
     {
-      outWriter.println(Messages.get("epubcheck_completed"));
-      outWriter.setQuiet(false);
+      printEpubCheckCompleted(report);
     }
     return returnValue;
+  }
+
+  private void printEpubCheckCompleted(Report report)
+  {
+    if(report != null) {
+      StringBuilder messageCount = new StringBuilder();
+      if(reportingLevel <= ReportingLevel.Fatal) {
+        messageCount.append(Messages.get("messages") + ": ");
+        messageCount.append(String.format(Messages.get("counter_fatal"), report.getFatalErrorCount()));
+      }
+      if(reportingLevel <= ReportingLevel.Error) {
+        messageCount.append(" / " + String.format(Messages.get("counter_error"), report.getErrorCount()));
+      }
+      if(reportingLevel <= ReportingLevel.Warning) {
+        messageCount.append(" / " + String.format(Messages.get("counter_warn"), report.getWarningCount()));
+      }
+      if(reportingLevel <= ReportingLevel.Info) {
+        messageCount.append(" / " + String.format(Messages.get("counter_info"), report.getInfoCount()));
+      }
+      if(reportingLevel <= ReportingLevel.Usage) {
+        messageCount.append(" / " + String.format(Messages.get("counter_usage"), report.getUsageCount()));
+      }
+      if(messageCount.length() > 0) {
+        messageCount.append("\n");
+        outWriter.println(messageCount);
+      }
+    }
+    outWriter.println(Messages.get("epubcheck_completed"));
+    outWriter.setQuiet(false);
   }
 
   private void dumpMessageDictionary(Report report)
@@ -360,12 +389,13 @@ public class EpubChecker
 
   public int processEpubFile(String[] args)
   {
+    Report report = null;
     int returnValue = 1;
     try
     {
       if (processArguments(args))
       {
-        Report report = createReport();
+        report = createReport();
         report.initialize();
         if (listChecks)
         {
@@ -388,8 +418,7 @@ public class EpubChecker
       returnValue = 1;
     } finally
     {
-      outWriter.println(Messages.get("epubcheck_completed"));
-      outWriter.setQuiet(false);
+      printEpubCheckCompleted(report);
     }
     return returnValue;
   }

--- a/src/main/resources/com/adobe/epubcheck/util/messages.properties
+++ b/src/main/resources/com/adobe/epubcheck/util/messages.properties
@@ -3,8 +3,15 @@ opv_version_test=*** Candidate for msg deletion *** Tests are performed only for
 mode_version_not_supported=The checker doesn't validate type %1$s and version %2$s.
 
 no_errors__or_warnings=No errors or warnings detected.
-there_were_errors=\nCheck finished with errors\n
-there_were_warnings=\nCheck finished with warnings\n
+there_were_errors=\nCheck finished with errors
+there_were_warnings=\nCheck finished with warnings
+
+messages=Messages
+counter_fatal=%1$d fatal
+counter_error=%1$d errors
+counter_warn=%1$d warnings
+counter_info=%1$d info
+counter_usage=%1$d usage
 
 error_processing_unexpanded_epub=\nThis check cannot process expanded epubs\n
 deleting_archive=\nEpub creation cancelled due to detected errors.\n

--- a/src/test/resources/com/adobe/epubcheck/test/command_line/severity_error_expected_results.txt
+++ b/src/test/resources/com/adobe/epubcheck/test/command_line/severity_error_expected_results.txt
@@ -6,6 +6,7 @@ ERROR(CSS-001): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.
 ERROR(CSS-001): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(56,5): The 'direction' property must not be included in an EPUB Style Sheet.
 
 Check finished with errors
+Messages: 0 fatal / 5 errors
 
 epubcheck completed
 Completed command_line test('severity_error')

--- a/src/test/resources/com/adobe/epubcheck/test/command_line/severity_fatal_expected_results.txt
+++ b/src/test/resources/com/adobe/epubcheck/test/command_line/severity_fatal_expected_results.txt
@@ -1,4 +1,6 @@
 Start command_line test('severity_fatal')
 No errors or warnings detected.
+Messages: 0 fatal
+
 epubcheck completed
 Completed command_line test('severity_fatal')

--- a/src/test/resources/com/adobe/epubcheck/test/command_line/severity_overrideBadId_expected_results.txt
+++ b/src/test/resources/com/adobe/epubcheck/test/command_line/severity_overrideBadId_expected_results.txt
@@ -77,6 +77,7 @@ USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(66,3): CSS class Selector is not used.
 
 Check finished with errors
+Messages: 0 fatal / 6 errors / 6 warnings / 0 info / 63 usage
 
 epubcheck completed
 Completed command_line test('severity_overrideBadId')

--- a/src/test/resources/com/adobe/epubcheck/test/command_line/severity_overrideBadMessage_expected_results.txt
+++ b/src/test/resources/com/adobe/epubcheck/test/command_line/severity_overrideBadMessage_expected_results.txt
@@ -78,6 +78,7 @@ USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(66,3): CSS class Selector is not used.
 
 Check finished with errors
+Messages: 0 fatal / 7 errors / 6 warnings / 0 info / 63 usage
 
 epubcheck completed
 Completed command_line test('severity_overrideBadMessage')

--- a/src/test/resources/com/adobe/epubcheck/test/command_line/severity_overrideBadSeverity_expected_results.txt
+++ b/src/test/resources/com/adobe/epubcheck/test/command_line/severity_overrideBadSeverity_expected_results.txt
@@ -77,6 +77,7 @@ USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(66,3): CSS class Selector is not used.
 
 Check finished with errors
+Messages: 0 fatal / 6 errors / 6 warnings / 0 info / 63 usage
 
 epubcheck completed
 Completed command_line test('severity_overrideBadSeverity')

--- a/src/test/resources/com/adobe/epubcheck/test/command_line/severity_overrideMissingFile_expected_results.txt
+++ b/src/test/resources/com/adobe/epubcheck/test/command_line/severity_overrideMissingFile_expected_results.txt
@@ -77,6 +77,7 @@ USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(66,3): CSS class Selector is not used.
 
 Check finished with errors
+Messages: 0 fatal / 6 errors / 6 warnings / 0 info / 63 usage
 
 epubcheck completed
 Completed command_line test('severity_overrideMissingFile')

--- a/src/test/resources/com/adobe/epubcheck/test/command_line/severity_overrideOk_expected_results.txt
+++ b/src/test/resources/com/adobe/epubcheck/test/command_line/severity_overrideOk_expected_results.txt
@@ -75,6 +75,7 @@ USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(66,3): CSS class Selector is not used.
 
 Check finished with errors
+Messages: 0 fatal / 7 errors / 6 warnings / 0 info / 60 usage
 
 epubcheck completed
 Completed command_line test('severity_overrideOk')

--- a/src/test/resources/com/adobe/epubcheck/test/command_line/severity_usage_expected_results.txt
+++ b/src/test/resources/com/adobe/epubcheck/test/command_line/severity_usage_expected_results.txt
@@ -76,6 +76,7 @@ USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(66,3): CSS class Selector is not used.
 
 Check finished with errors
+Messages: 0 fatal / 5 errors / 6 warnings / 0 info / 63 usage
 
 epubcheck completed
 Completed command_line test('severity_usage')

--- a/src/test/resources/com/adobe/epubcheck/test/command_line/severity_warning_expected_results.txt
+++ b/src/test/resources/com/adobe/epubcheck/test/command_line/severity_warning_expected_results.txt
@@ -12,6 +12,7 @@ WARNING(CSS-017): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/cssS
 WARNING(CSS-017): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(17,13): CSS selector specifies absolute position.
 
 Check finished with errors
+Messages: 0 fatal / 5 errors / 6 warnings
 
 epubcheck completed
 Completed command_line test('severity_warning')


### PR DESCRIPTION
fixes #655

To be able to implement this I had to change the `Report` interface and add two new methods `getInfoCount()` and `getUsageCount()`.

However, this change may break existing Java implementations using the plain `Report` interface instead inheriting from `MasterReport`.

So this definately needs to be in a Minor release rather than a Bugfix release.