### PR TITLE
[Fix 773] No empty references in XML output

### DIFF
--- a/src/main/java/com/adobe/epubcheck/css/CSSHandler.java
+++ b/src/main/java/com/adobe/epubcheck/css/CSSHandler.java
@@ -333,7 +333,9 @@ public class CSSHandler implements CssContentHandler, CssErrorHandler
             (((fontStyle != null) && !"normal".equalsIgnoreCase(fontStyle)) ? "," + fontStyle : "") +
             (((fontWeight != null) && !"normal".equalsIgnoreCase(fontWeight)) ? "," + fontWeight : "")
         );
-        report.info(path, FeatureEnum.REFERENCE, fontUri);
+        if (fontUri != null) {
+        	report.info(path, FeatureEnum.REFERENCE, fontUri);
+        }
       }
     }
   }

--- a/src/main/java/com/adobe/epubcheck/util/XmlReportAbstract.java
+++ b/src/main/java/com/adobe/epubcheck/util/XmlReportAbstract.java
@@ -122,6 +122,9 @@ public abstract class XmlReportAbstract extends MasterReport {
 
 	@Override
 	public void info(String resource, FeatureEnum feature, String value) {
+		// Dont store 'null' values
+		if (value == null) return;
+		
 		switch (feature) {
 		case TOOL_DATE:
 			if (value != null && !value.startsWith("$")) {

--- a/src/main/java/com/adobe/epubcheck/util/XmlReportImpl.java
+++ b/src/main/java/com/adobe/epubcheck/util/XmlReportImpl.java
@@ -164,7 +164,7 @@ public class XmlReportImpl extends XmlReportAbstract
           generateElement("name", "Font");
           startElement("values", KeyValue.with("arity", "List"), KeyValue.with("type", "Property"));
           generateProperty("FontName", getNameFromPath(f), "String");
-          generateProperty("FontFile", false);
+          generateProperty("FontFile", true);
           endElement("values");
           endElement("property");
         }

--- a/src/test/java/com/adobe/epubcheck/test/css_Test.java
+++ b/src/test/java/com/adobe/epubcheck/test/css_Test.java
@@ -59,6 +59,12 @@ public class css_Test
     runCSSXmpTest("font-face", 1);
   }
 
+  @Test
+  public void font_family_no_src_xml_Test() throws Exception
+  {
+    runCSSXmlTest("font-family-no-src", 1);
+  }
+
   // @Test
   public void unused_epub3_Test() throws Exception
   {

--- a/src/test/resources/com/adobe/epubcheck/test/css/font-family-no-src/META-INF/container.xml
+++ b/src/test/resources/com/adobe/epubcheck/test/css/font-family-no-src/META-INF/container.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+   <rootfiles>
+      <rootfile full-path="OPS/content.opf" media-type="application/oebps-package+xml"/>
+   </rootfiles>
+</container>

--- a/src/test/resources/com/adobe/epubcheck/test/css/font-family-no-src/OPS/content.opf
+++ b/src/test/resources/com/adobe/epubcheck/test/css/font-family-no-src/OPS/content.opf
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<package xmlns="http://www.idpf.org/2007/opf" unique-identifier="BOGUS" version="3.0">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title>Font Face Sample Book</dc:title>
+    <dc:language>en</dc:language>
+    <dc:identifier id="BOGUS">000000000000000000</dc:identifier>
+    <meta property="dcterms:modified">2012-10-10T12:00:00Z</meta>
+  </metadata>
+  <manifest>
+    <item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml" />
+    <item id="toc" properties="nav" href="toc.xhtml" media-type="application/xhtml+xml"/>
+    <item id="page01" href="external_css.xhtml" media-type="application/xhtml+xml" />
+    <item id="page02" href="style_tag_css.xhtml" media-type="application/xhtml+xml" />
+    <item id="page03" href="inline_css.xhtml" media-type="application/xhtml+xml" />
+    <item id="style" href="styles/style.css" media-type="text/css"/>
+  </manifest>
+  <spine toc="ncx">
+    <itemref idref="page01" />
+    <itemref idref="page02" />
+    <itemref idref="page03" />
+  </spine>
+</package>

--- a/src/test/resources/com/adobe/epubcheck/test/css/font-family-no-src/OPS/external_css.xhtml
+++ b/src/test/resources/com/adobe/epubcheck/test/css/font-family-no-src/OPS/external_css.xhtml
@@ -1,0 +1,60 @@
+<?xml version="1.0"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>Font-Face - External CSS</title>
+    <link rel="stylesheet" type="text/css" href="styles/style.css"/>
+</head>
+<body>
+<div>
+    <h1>Font-Face specified in external css file</h1>
+    <table>
+        <tr>
+            <td>
+                <div class="myFont">This is standard font.</div>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div class="myFont1">This should be a different font.</div>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div class="myFont2">This should be a different font.</div>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div class="myFont3">This should be a different font.</div>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div class="myFont4">This references a missing font.</div>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div class="myFont5">This references an incorrect font path.</div>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div class="myFont6">This references a null font path.</div>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div class="ex1">This references font style.</div>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div class="myFont7">This references an external font</div>
+            </td>
+        </tr>
+    </table>
+</div>
+</body>
+</html>

--- a/src/test/resources/com/adobe/epubcheck/test/css/font-family-no-src/OPS/inline_css.xhtml
+++ b/src/test/resources/com/adobe/epubcheck/test/css/font-family-no-src/OPS/inline_css.xhtml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>Font-Face - Inline CSS</title>
+</head>
+<body>
+<h1>Font-Face - Inline CSS</h1>
+
+<p>Using the @font-face rule isn't possible inline.</p>
+</body>
+</html>

--- a/src/test/resources/com/adobe/epubcheck/test/css/font-family-no-src/OPS/style_tag_css.xhtml
+++ b/src/test/resources/com/adobe/epubcheck/test/css/font-family-no-src/OPS/style_tag_css.xhtml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <title>Font-Face - Style Tag CSS</title>
+    <style>
+        @font-face {
+            font-family: "bloody";
+            src: url('fonts/bloody.woff');
+        }
+
+        @font-face {
+            font-family: "badaboom";
+            src: url('fonts/badaboom.woff');
+        }
+
+        div {
+            font-family: bloody;
+        }
+
+        .noRef{
+            font-family: "badaboom";
+        }
+
+        .externalFont {
+            font-family: 'Chela One';
+        }
+    </style>
+</head>
+<body>
+
+<p><b>Note:</b> Internet Explorer 9 only supports .eot fonts.</p>
+
+<div>
+    This is an embedded font.
+</div>
+     <p class="noRef">Reference to font that is missing from the package.</p>
+     <p class="externalFont">Reference to an external font.</p>
+</body>
+</html>

--- a/src/test/resources/com/adobe/epubcheck/test/css/font-family-no-src/OPS/styles/style.css
+++ b/src/test/resources/com/adobe/epubcheck/test/css/font-family-no-src/OPS/styles/style.css
@@ -1,0 +1,68 @@
+@font-face {
+    font-family: brankovic;
+}
+
+@font-face {
+    font-family: fummel;
+}
+
+@font-face {
+    font-family: "bloody";
+}
+
+@font-face {
+    font-family: "bloody_wrong";
+}
+
+@font-face {
+    font-family: "badaboom";
+}
+
+.ex1 {
+    font: 5em arial, sans-serif
+}
+
+.myFont {
+    font-size: xx-large;
+    color: maroon;
+}
+
+.myFont1 {
+    font-family: brankovic;
+    font-size: xx-large;
+    color: maroon;
+}
+
+.myFont2 {
+    font-family: fummel;
+    font-size: xx-large;
+    color: maroon;
+}
+
+.myFont3 {
+    font-family: bloody;
+    font-size: xx-large;
+    color: maroon;
+}
+
+.myFont4 {
+    font-family: badaboom;
+    font-size: xx-large;
+    color: maroon;
+}
+
+.myFont5 {
+    font-family: bloody_wrong;
+    font-size: xx-large;
+    color: maroon;
+}
+
+.myFont6 {
+    font-family: null;
+    font-size: 3em;
+    color: #8a2be2;
+}
+
+.myFont7 {
+    font-family: "Bitstream Vera Serif Bold", serif
+}

--- a/src/test/resources/com/adobe/epubcheck/test/css/font-family-no-src/OPS/toc.ncx
+++ b/src/test/resources/com/adobe/epubcheck/test/css/font-family-no-src/OPS/toc.ncx
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ncx xmlns="http://www.daisy.org/z3986/2005/ncx/" version="2005-1">
+  <head>
+    <meta name="dtb:uid" content=""/>
+    <meta name="dtb:depth" content="1"/>
+    <meta name="dtb:totalPageCount" content="0"/>
+    <meta name="dtb:maxPageNumber" content="0"/>
+  </head>
+  <docTitle>
+    <text>Transform Style Test</text>
+  </docTitle>  
+  <navMap>
+    <navPoint id="np-1" playOrder="1">
+      <navLabel>
+	<text>Font-Face - External CSS</text>
+      </navLabel>
+      <content src="external_css.xhtml"/>
+    </navPoint>
+  </navMap>
+</ncx>

--- a/src/test/resources/com/adobe/epubcheck/test/css/font-family-no-src/OPS/toc.xhtml
+++ b/src/test/resources/com/adobe/epubcheck/test/css/font-family-no-src/OPS/toc.xhtml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en" lang="en">
+
+<head>
+    <title>Table of Contents</title>
+</head>
+<body>
+<nav epub:type="toc">
+    <ol>
+        <li><a href="external_css.xhtml">External CSS</a></li>
+        <li><a href="style_tag_css.xhtml">Style Tag</a></li>
+        <li><a href="inline_css.xhtml">Inline Style</a></li>
+    </ol>
+</nav>
+</body>
+</html>

--- a/src/test/resources/com/adobe/epubcheck/test/css/font-family-no-src/mimetype
+++ b/src/test/resources/com/adobe/epubcheck/test/css/font-family-no-src/mimetype
@@ -1,0 +1,1 @@
+application/epub+zip

--- a/src/test/resources/com/adobe/epubcheck/test/css/font-family-no-src_expected_results.xml
+++ b/src/test/resources/com/adobe/epubcheck/test/css/font-family-no-src_expected_results.xml
@@ -1,0 +1,219 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jhove xmlns="http://hul.harvard.edu/ois/xml/ns/jhove"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       date="2017-07-01"
+       name="epubcheck"
+       release="4.0.3-SNAPSHOT"
+       xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/jhove http://hul.harvard.edu/ois/xml/xsd/jhove/jhove.xsd">
+   <date>2017-07-01T18:25:40+02:00</date>
+   <repInfo uri="epubcheck\target\test-classes\com\adobe\epubcheck\test\css\font-family-no-src.epub">
+      <created>2017-07-01T18:19:18Z</created>
+      <lastModified>2012-10-10T12:00:00Z</lastModified>
+      <format>application/epub+zip</format>
+      <version>3.0.1</version>
+      <status>Not well-formed</status>
+      <messages>
+         <message severity="error" subMessage="RSC-007">RSC-007, ERROR, [Referenced resource 'OPS/fonts/bloody.woff' could not be found in the EPUB.], OPS/style_tag_css.xhtml (9-13)</message>
+         <message severity="error" subMessage="RSC-007">RSC-007, ERROR, [Referenced resource 'OPS/fonts/badaboom.woff' could not be found in the EPUB.], OPS/style_tag_css.xhtml (14-13)</message>
+         <message severity="info" subMessage="ACC-007">ACC-007, HINT, [Content Documents do not use 'epub:type' attributes for semantic inflection.], OPS/external_css.xhtml</message>
+         <message severity="info" subMessage="ACC-007">ACC-007, HINT, [Content Documents do not use 'epub:type' attributes for semantic inflection.], OPS/style_tag_css.xhtml</message>
+         <message severity="info" subMessage="ACC-007">ACC-007, HINT, [Content Documents do not use 'epub:type' attributes for semantic inflection.], OPS/inline_css.xhtml</message>
+         <message severity="info" subMessage="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], OPS/style_tag_css.xhtml (8-13)</message>
+         <message severity="info" subMessage="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], OPS/style_tag_css.xhtml (9-13)</message>
+         <message severity="info" subMessage="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], OPS/style_tag_css.xhtml (13-13)</message>
+         <message severity="info" subMessage="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], OPS/style_tag_css.xhtml (14-13)</message>
+         <message severity="info" subMessage="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], OPS/styles/style.css (2-5)</message>
+         <message severity="info" subMessage="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], OPS/styles/style.css (6-5)</message>
+         <message severity="info" subMessage="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], OPS/styles/style.css (10-5)</message>
+         <message severity="info" subMessage="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], OPS/styles/style.css (14-5)</message>
+         <message severity="info" subMessage="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], OPS/styles/style.css (18-5)</message>
+         <message severity="info" subMessage="HTM-038">HTM-038, HINT, [Ensure b, i, em, and strong elements are used in compliance with W3C HTML5 directives.], OPS/style_tag_css.xhtml (32-7)</message>
+         <message severity="info" subMessage="ACC-008">ACC-008, HINT, [Navigation Document has no 'landmarks nav' element.], OPS/toc.xhtml</message>
+         <message severity="info" subMessage="HTM-010">HTM-010, HINT, [Namespace uri 'http://www.daisy.org/z3986/2005/ncx/' was found.], OPS/toc.ncx (2-68)</message>
+         <message severity="info" subMessage="OPF-059">OPF-059, HINT, [Spine item has no NCX entry reference.], OPS/toc.ncx</message>
+         <message severity="info" subMessage="OPF-059">OPF-059, HINT, [Spine item has no NCX entry reference.], OPS/toc.ncx</message>
+         <message severity="info" subMessage="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size.], OPS/styles/style.css (26-5)</message>
+         <message severity="info" subMessage="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size.], OPS/styles/style.css (32-5)</message>
+         <message severity="info" subMessage="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size.], OPS/styles/style.css (38-5)</message>
+         <message severity="info" subMessage="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size.], OPS/styles/style.css (44-5)</message>
+         <message severity="info" subMessage="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size.], OPS/styles/style.css (50-5)</message>
+         <message severity="info" subMessage="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size.], OPS/styles/style.css (56-5)</message>
+      </messages>
+      <mimeType>application/epub+zip</mimeType>
+      <properties>
+         <property>
+            <name>CharacterCount</name>
+            <values arity="Scalar" type="Long">
+               <value>1772</value>
+            </values>
+         </property>
+         <property>
+            <name>Language</name>
+            <values arity="Scalar" type="String">
+               <value>en</value>
+            </values>
+         </property>
+         <property>
+            <name>Info</name>
+            <values arity="List" type="Property">
+               <property>
+                  <name>Identifier</name>
+                  <values arity="Scalar" type="String">
+                     <value>000000000000000000</value>
+                  </values>
+               </property>
+               <property>
+                  <name>CreationDate</name>
+                  <values arity="Scalar" type="Date">
+                     <value>2017-07-01T18:19:18Z</value>
+                  </values>
+               </property>
+               <property>
+                  <name>ModDate</name>
+                  <values arity="Scalar" type="Date">
+                     <value>2012-10-10T12:00:00Z</value>
+                  </values>
+               </property>
+               <property>
+                  <name>Title</name>
+                  <values arity="Scalar" type="String">
+                     <value>Font Face Sample Book</value>
+                  </values>
+               </property>
+            </values>
+         </property>
+         <property>
+            <name>Fonts</name>
+            <values arity="List" type="Property">
+               <property>
+                  <name>Font</name>
+                  <values arity="List" type="Property">
+                     <property>
+                        <name>FontName</name>
+                        <values arity="Scalar" type="String">
+                           <value>bloody</value>
+                        </values>
+                     </property>
+                     <property>
+                        <name>FontFile</name>
+                        <values arity="Scalar" type="Boolean">
+                           <value>true</value>
+                        </values>
+                     </property>
+                  </values>
+               </property>
+               <property>
+                  <name>Font</name>
+                  <values arity="List" type="Property">
+                     <property>
+                        <name>FontName</name>
+                        <values arity="Scalar" type="String">
+                           <value>badaboom</value>
+                        </values>
+                     </property>
+                     <property>
+                        <name>FontFile</name>
+                        <values arity="Scalar" type="Boolean">
+                           <value>true</value>
+                        </values>
+                     </property>
+                  </values>
+               </property>
+               <property>
+                  <name>Font</name>
+                  <values arity="List" type="Property">
+                     <property>
+                        <name>FontName</name>
+                        <values arity="Scalar" type="String">
+                           <value>brankovic</value>
+                        </values>
+                     </property>
+                     <property>
+                        <name>FontFile</name>
+                        <values arity="Scalar" type="Boolean">
+                           <value>false</value>
+                        </values>
+                     </property>
+                  </values>
+               </property>
+               <property>
+                  <name>Font</name>
+                  <values arity="List" type="Property">
+                     <property>
+                        <name>FontName</name>
+                        <values arity="Scalar" type="String">
+                           <value>fummel</value>
+                        </values>
+                     </property>
+                     <property>
+                        <name>FontFile</name>
+                        <values arity="Scalar" type="Boolean">
+                           <value>false</value>
+                        </values>
+                     </property>
+                  </values>
+               </property>
+               <property>
+                  <name>Font</name>
+                  <values arity="List" type="Property">
+                     <property>
+                        <name>FontName</name>
+                        <values arity="Scalar" type="String">
+                           <value>bloody</value>
+                        </values>
+                     </property>
+                     <property>
+                        <name>FontFile</name>
+                        <values arity="Scalar" type="Boolean">
+                           <value>false</value>
+                        </values>
+                     </property>
+                  </values>
+               </property>
+               <property>
+                  <name>Font</name>
+                  <values arity="List" type="Property">
+                     <property>
+                        <name>FontName</name>
+                        <values arity="Scalar" type="String">
+                           <value>bloody_wrong</value>
+                        </values>
+                     </property>
+                     <property>
+                        <name>FontFile</name>
+                        <values arity="Scalar" type="Boolean">
+                           <value>false</value>
+                        </values>
+                     </property>
+                  </values>
+               </property>
+               <property>
+                  <name>Font</name>
+                  <values arity="List" type="Property">
+                     <property>
+                        <name>FontName</name>
+                        <values arity="Scalar" type="String">
+                           <value>badaboom</value>
+                        </values>
+                     </property>
+                     <property>
+                        <name>FontFile</name>
+                        <values arity="Scalar" type="Boolean">
+                           <value>false</value>
+                        </values>
+                     </property>
+                  </values>
+               </property>
+            </values>
+         </property>
+         <property>
+            <name>MediaTypes</name>
+            <values arity="Array" type="String">
+               <value>application/x-dtbncx+xml</value>
+               <value>application/xhtml+xml</value>
+               <value>text/css</value>
+            </values>
+         </property>
+      </properties>
+   </repInfo>
+</jhove>

--- a/src/test/resources/com/adobe/epubcheck/test/css/font_encryption_idpf_expected_results.xml
+++ b/src/test/resources/com/adobe/epubcheck/test/css/font_encryption_idpf_expected_results.xml
@@ -129,7 +129,7 @@
        <property>
         <name>FontFile</name>
         <values arity="Scalar" type="Boolean">
-         <value>false</value>
+         <value>true</value>
         </values>
        </property>
       </values>
@@ -146,7 +146,7 @@
        <property>
         <name>FontFile</name>
         <values arity="Scalar" type="Boolean">
-         <value>false</value>
+         <value>true</value>
         </values>
        </property>
       </values>
@@ -163,7 +163,7 @@
        <property>
         <name>FontFile</name>
         <values arity="Scalar" type="Boolean">
-         <value>false</value>
+         <value>true</value>
         </values>
        </property>
       </values>
@@ -180,7 +180,7 @@
        <property>
         <name>FontFile</name>
         <values arity="Scalar" type="Boolean">
-         <value>false</value>
+         <value>true</value>
         </values>
        </property>
       </values>
@@ -197,7 +197,7 @@
        <property>
         <name>FontFile</name>
         <values arity="Scalar" type="Boolean">
-         <value>false</value>
+         <value>true</value>
         </values>
        </property>
       </values>
@@ -214,7 +214,7 @@
        <property>
         <name>FontFile</name>
         <values arity="Scalar" type="Boolean">
-         <value>false</value>
+         <value>true</value>
         </values>
        </property>
       </values>
@@ -231,7 +231,7 @@
        <property>
         <name>FontFile</name>
         <values arity="Scalar" type="Boolean">
-         <value>false</value>
+         <value>true</value>
         </values>
        </property>
       </values>
@@ -248,7 +248,7 @@
        <property>
         <name>FontFile</name>
         <values arity="Scalar" type="Boolean">
-         <value>false</value>
+         <value>true</value>
         </values>
        </property>
       </values>
@@ -265,7 +265,7 @@
        <property>
         <name>FontFile</name>
         <values arity="Scalar" type="Boolean">
-         <value>false</value>
+         <value>true</value>
         </values>
        </property>
       </values>
@@ -282,7 +282,7 @@
        <property>
         <name>FontFile</name>
         <values arity="Scalar" type="Boolean">
-         <value>false</value>
+         <value>true</value>
         </values>
        </property>
       </values>
@@ -299,7 +299,7 @@
        <property>
         <name>FontFile</name>
         <values arity="Scalar" type="Boolean">
-         <value>false</value>
+         <value>true</value>
         </values>
        </property>
       </values>
@@ -316,7 +316,7 @@
        <property>
         <name>FontFile</name>
         <values arity="Scalar" type="Boolean">
-         <value>false</value>
+         <value>true</value>
         </values>
        </property>
       </values>

--- a/src/test/resources/com/adobe/epubcheck/test/encryption/epub30_font_obfuscation.epub_expected_results.xml
+++ b/src/test/resources/com/adobe/epubcheck/test/encryption/epub30_font_obfuscation.epub_expected_results.xml
@@ -83,7 +83,7 @@
        <property>
         <name>FontFile</name>
         <values arity="Scalar" type="Boolean">
-         <value>false</value>
+         <value>true</value>
         </values>
        </property>
       </values>
@@ -100,7 +100,7 @@
        <property>
         <name>FontFile</name>
         <values arity="Scalar" type="Boolean">
-         <value>false</value>
+         <value>true</value>
         </values>
        </property>
       </values>
@@ -117,7 +117,7 @@
        <property>
         <name>FontFile</name>
         <values arity="Scalar" type="Boolean">
-         <value>false</value>
+         <value>true</value>
         </values>
        </property>
       </values>


### PR DESCRIPTION
Avoid storing 'null' value in feature
Handle no src uri in fonts, fixes #773, 
Add a unit test 'font-family-no-src' to test for the case refer in #773 
Correct embedded font boolean in xml output