### PR TITLE
[fix #303] Check MimeType uncompressed

### DIFF
--- a/src/main/java/com/adobe/epubcheck/api/EpubCheck.java
+++ b/src/main/java/com/adobe/epubcheck/api/EpubCheck.java
@@ -308,6 +308,10 @@ public class EpubCheck implements DocumentValidator
       {
         report.message(MessageId.PKG_006, EPUBLocation.create(epubFile.getName()));
       }
+      else if (!CheckUtil.checkString(header, 38, "application/epub+zip"))
+      {
+        report.message(MessageId.PKG_007, EPUBLocation.create("mimetype"));
+      }
     }
   }
 

--- a/src/main/java/com/adobe/epubcheck/util/CheckUtil.java
+++ b/src/main/java/com/adobe/epubcheck/util/CheckUtil.java
@@ -69,12 +69,15 @@ public class CheckUtil
     {
       if ((c = input.read()) == -1)
       {
-        return false;
+        return true; // ignored; should be checked by checkEpubHeader() in com.adobe.epubcheck.api.EpubCheck
       }
       else
       {
         baos.write(c);
       }
+    }
+    if (! baos.toString().equals("application/epub+zip")) {
+        return true; // ignored; should be checked by checkEpubHeader() in com.adobe.epubcheck.api.EpubCheck
     }
 
     int ch = input.read();

--- a/src/test/java/com/adobe/epubcheck/ocf/OCFCheckerTest.java
+++ b/src/test/java/com/adobe/epubcheck/ocf/OCFCheckerTest.java
@@ -394,24 +394,6 @@ public class OCFCheckerTest
   }
 
   @Test
-  public void testInvalidLoremMimetype30()
-  {
-    ValidationReport testReport = testOcfPackage("/30/expanded/invalid/lorem-mimetype/",
-        EPUBVersion.VERSION_3);
-    if (1 != testReport.getErrorCount() || 0 != testReport.getWarningCount())
-    {
-      outWriter.println(testReport);
-    }
-
-    List<MessageId> errors = new ArrayList<MessageId>();
-    Collections.addAll(errors, MessageId.PKG_007);
-    assertEquals(errors, testReport.getErrorIds());
-    assertEquals(0, testReport.getWarningCount());
-
-    assertTrue(testReport.hasInfoMessage("[format version] 3.0.1"));
-  }
-
-  @Test
   public void testInvalidLoremPoster30()
   {
     ValidationReport testReport = testOcfPackage("/30/expanded/invalid/lorem-poster/",


### PR DESCRIPTION
* To check that mimetype file in EPUB is not comressed, add a check in `checkEpubHeader()`
* to avoid checking twice, ignore some checks in `checkTrailingSpaces()`

For EPUB files in https://github.com/IDPF/epubcheck/issues/303#issuecomment-260916592 , epubcheck with this patch finds 1 error in epub30-spec_compressed.epub , but no errors in epub30-spec_uncompressed.epub.