### PR TITLE
[fix #666] handle IllegalStateException in checkItemContent

### DIFF
--- a/src/main/java/com/adobe/epubcheck/messages/MessageDictionary.java
+++ b/src/main/java/com/adobe/epubcheck/messages/MessageDictionary.java
@@ -92,6 +92,7 @@ public class MessageDictionary
       map.put(MessageId.CHK_005, Severity.ERROR);
       map.put(MessageId.CHK_006, Severity.ERROR);
       map.put(MessageId.CHK_007, Severity.ERROR);
+      map.put(MessageId.CHK_008, Severity.ERROR);
 
       // CSS
       map.put(MessageId.CSS_001, Severity.ERROR);

--- a/src/main/java/com/adobe/epubcheck/messages/MessageId.java
+++ b/src/main/java/com/adobe/epubcheck/messages/MessageId.java
@@ -55,6 +55,7 @@ public enum MessageId implements Comparable<MessageId>
   CHK_005("CHK-005"),
   CHK_006("CHK-006"),
   CHK_007("CHK-007"),
+  CHK_008("CHK-008"),
 
   // Messages associated with styles
   CSS_001("CSS-001"),

--- a/src/main/java/com/adobe/epubcheck/opf/OPFChecker.java
+++ b/src/main/java/com/adobe/epubcheck/opf/OPFChecker.java
@@ -416,11 +416,15 @@ public class OPFChecker implements DocumentValidator, ContentChecker
     }
     if (checkerFactory != null)
     {
-      // Create the content checker with an overridden validation context
-      ContentChecker checker = checkerFactory.newInstance(new ValidationContextBuilder(context)
-          .path(item.getPath()).mimetype(mimetype).properties(item.getProperties()).build());
-      // Validate
-      checker.runChecks();
+      try {
+        // Create the content checker with an overridden validation context
+        ContentChecker checker = checkerFactory.newInstance(new ValidationContextBuilder(context)
+            .path(item.getPath()).mimetype(mimetype).properties(item.getProperties()).build());
+        // Validate
+        checker.runChecks();
+      } catch (IllegalStateException e) {
+        report.message(MessageId.CHK_008, EPUBLocation.create(path), item.getPath());
+      }
     }
   }
 

--- a/src/main/resources/com/adobe/epubcheck/messages/MessageBundle.properties
+++ b/src/main/resources/com/adobe/epubcheck/messages/MessageBundle.properties
@@ -32,6 +32,7 @@ CHK_004=The custom message contains too many parameters in message overrides fil
 CHK_005=The custom suggestion contains too many parameters in message overrides file '%1$s'.
 CHK_006=Unable to parse the custom format parameter in message overrides file '%1$s'.
 CHK_007=Error encountered while processing custom message file '%1$s': "%2$s".
+CHK_008=Error encountered while processing an item '%1$s'; skip other checkes for the item.
 
 #CSS
 CSS_001=The \'%1$s\' property must not be included in an EPUB Style Sheet.

--- a/src/test/java/com/adobe/epubcheck/api/Epub20CheckTest.java
+++ b/src/test/java/com/adobe/epubcheck/api/Epub20CheckTest.java
@@ -265,4 +265,12 @@ public class Epub20CheckTest extends AbstractEpubCheckTest
 	  Collections.addAll(expectedErrors, MessageId.RSC_007);
     testValidateDocument("invalid/issue316.epub");
 	}
+
+  @Test
+  public void testValidateEPUB_issue21()
+  {
+    Collections.addAll(expectedErrors, MessageId.OPF_054, MessageId.OPF_050, MessageId.CHK_008);
+    Collections.addAll(expectedWarnings, MessageId.OPF_055);
+    testValidateDocument("/Issue21.epub");
+  }
 }


### PR DESCRIPTION
fixes #666 

Catch errors when initializing of NCXChacker, NavChecker and other Checker classes' object and report CHK_008, new MessageId instance.

This PR is not complete solution of `Preconditions.checkXXX` methods issue said https://github.com/IDPF/epubcheck/issues/666#issuecomment-175738402, but may be a reasonable workaround.