### PR TITLE
use default validation profile against EPUB 2.0 file

### DIFF
--- a/src/main/java/com/adobe/epubcheck/ocf/OCFChecker.java
+++ b/src/main/java/com/adobe/epubcheck/ocf/OCFChecker.java
@@ -209,6 +209,7 @@ public class OCFChecker
     {
       // Validation profile is unsupported for EPUB 2.0
       report.message(MessageId.PKG_023, EPUBLocation.create(opfPaths.get(0)));
+      validationProfile = EPUBProfile.DEFAULT;
     }
     else if (validationVersion == EPUBVersion.VERSION_3)
     {

--- a/src/test/java/com/adobe/epubcheck/api/Epub20CheckTest.java
+++ b/src/test/java/com/adobe/epubcheck/api/Epub20CheckTest.java
@@ -46,6 +46,13 @@ public class Epub20CheckTest extends AbstractEpubCheckTest
   }
 
   @Test
+  public void testValidateEPUBvalid20WithProfile()
+  {
+    EPUBProfile profile = EPUBProfile.DICT;
+    testValidateDocument("valid/lorem.epub", profile);
+  }
+
+  @Test
   public void testValidateEPUBInvalid20()
   {
     Collections.addAll(expectedErrors, MessageId.PKG_007);

--- a/src/test/java/com/adobe/epubcheck/test/message_coverage.java
+++ b/src/test/java/com/adobe/epubcheck/test/message_coverage.java
@@ -52,7 +52,6 @@ public class message_coverage
     expectedMissedCoverage.add(MessageId.OPF_011); //This is currently reported as RSC_005 in Schematron, but would be safer in prefix-checked code
     expectedMissedCoverage.add(MessageId.PKG_005); //This is only reported in an exception that is difficult to generate in a test
     expectedMissedCoverage.add(MessageId.PKG_015); //This is only reported in an exception that is difficult to generate in a test
-    expectedMissedCoverage.add(MessageId.PKG_023); //TODO add tests
     expectedMissedCoverage.add(MessageId.RSC_022); //If a LinkageError happens when running Java 6
 
     Assert.assertEquals("Messages not covered by tests", expectedMissedCoverage, allMessages);


### PR DESCRIPTION
## Before

```
$ java -Duser.language=en -jar target/epubcheck.jar -u --profile preview src/test/resources/20/epub/valid/lorem.epub 
Validating using EPUB version 2.0.1 rules.
USAGE(PKG-023): src/test/resources/20/epub/valid/lorem.epub/EPUB/lorem.opf(-1,-1): Validating the EPUB against version 2.0, default validation profile will be used.
ERROR(RSC-005): src/test/resources/20/epub/valid/lorem.epub/EPUB/lorem.opf(3,59): Error while parsing file: An EPUB Preview publication must have a 'preview' dc:type.
WARNING(RSC-017): src/test/resources/20/epub/valid/lorem.epub/EPUB/lorem.opf(3,59): Warning while parsing file: An EPUB Preview publication should link back to its source Publication using a dc:source element.
USAGE(HTM-010): src/test/resources/20/epub/valid/lorem.epub/EPUB/lorem.ncx(5,19): Namespace uri 'http://www.daisy.org/z3986/2005/ncx/' was found.
USAGE(HTM-010): src/test/resources/20/epub/valid/lorem.epub/EPUB/lorem.ncx(5,19): Namespace uri 'http://www.daisy.org/z3986/2005/ncx/' was found.
USAGE(CSS-022): src/test/resources/20/epub/valid/lorem.epub/EPUB/lorem.css(2,5): CSS selector specifies global margin setting.
USAGE(CSS-022): src/test/resources/20/epub/valid/lorem.epub/EPUB/lorem.css(3,5): CSS selector specifies global margin setting.
USAGE(HTM-021): src/test/resources/20/epub/valid/lorem.epub/EPUB/lorem.xhtml(-1,-1): Content file doesn't contain lang attribute.

Check finished with errors
Messages: 0 fatal / 1 errors / 1 warnings / 0 info / 6 usage

epubcheck completed
```

## After

```
$ java -Duser.language=en -jar target/epubcheck.jar -u --profile preview src/test/resources/20/epub/valid/lorem.epub 
Validating using EPUB version 2.0.1 rules.
USAGE(PKG-023): src/test/resources/20/epub/valid/lorem.epub/EPUB/lorem.opf(-1,-1): Validating the EPUB against version 2.0, default validation profile will be used.
USAGE(HTM-010): src/test/resources/20/epub/valid/lorem.epub/EPUB/lorem.ncx(5,19): Namespace uri 'http://www.daisy.org/z3986/2005/ncx/' was found.
USAGE(HTM-010): src/test/resources/20/epub/valid/lorem.epub/EPUB/lorem.ncx(5,19): Namespace uri 'http://www.daisy.org/z3986/2005/ncx/' was found.
USAGE(CSS-022): src/test/resources/20/epub/valid/lorem.epub/EPUB/lorem.css(2,5): CSS selector specifies global margin setting.
USAGE(CSS-022): src/test/resources/20/epub/valid/lorem.epub/EPUB/lorem.css(3,5): CSS selector specifies global margin setting.
USAGE(HTM-021): src/test/resources/20/epub/valid/lorem.epub/EPUB/lorem.xhtml(-1,-1): Content file doesn't contain lang attribute.
No errors or warnings detected.
Messages: 0 fatal / 0 errors / 0 warnings / 0 info / 6 usage

epubcheck completed
```

I'm not sure this behavior is correct, but the message `Validating the EPUB against version 2.0, default validation profile will be used.` means this change.

