### PR TITLE
Updating Travis config to use openjdk7 instead of oraclejdk7 which isn't supported by Travis anymore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+group: deprecated-2017Q3
 language: java
 jdk:
   - oraclejdk8
@@ -8,7 +9,6 @@ after_success: .travis/after_success.sh
 branches:
   only:
   - master
-  - contrib/nook
 env:
   global:
   - secure: gcpUIktuajGHvn95bzMg9Nqay+kGAdKXWOosA6sQHvaK+KCsiP4nhAMX5rWUYvk3XnEs2WlfZUBO7/aDcpX4fjZozs8fHbVuSfftYP+4MIIhEI2FNEXp823EShSRB32cGmEkdUh7OQdv5zN8SEQNW9MJguLSvTkp2FGYEsV3x1g=

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ group: deprecated-2017Q3
 language: java
 jdk:
   - oraclejdk8
-  - oraclejdk7
+  - openjdk7
 before_install: .travis/before_install.sh
 script: mvn verify
 after_success: .travis/after_success.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: required
 group: deprecated-2017Q3
 language: java
 jdk:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-group: deprecated-2017Q3
 language: java
 jdk:
   - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: required
 group: deprecated-2017Q3
 language: java
 jdk:


### PR DESCRIPTION
to use deprecated trusty image after [failures](https://travis-ci.org/IDPF/epubcheck/jobs/276550358)

https://blog.travis-ci.com/2017-08-29-trusty-image-updates