### PR TITLE
[fix #674] update Saxon dependency to latest 9.7 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,7 @@
         <dependency>
             <groupId>net.sf.saxon</groupId>
             <artifactId>Saxon-HE</artifactId>
-            <version>9.6.0-10</version>
+            <version>9.7.0-21</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Update Saxon dependency to latest 9.7 release.
The latest release in 9.7 branch is 9.7.0-21.
The source code for Saxon-HE is available on SourceForge:
https://sourceforge.net/projects/saxon/files/Saxon-HE/9.7/

resolves #674 