### PR TITLE
update to saxon 9.8.0-7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,7 @@
         <dependency>
             <groupId>net.sf.saxon</groupId>
             <artifactId>Saxon-HE</artifactId>
-            <version>9.8.0-7</version>
+            <version>9.8.0-8</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,7 @@
         <dependency>
             <groupId>net.sf.saxon</groupId>
             <artifactId>Saxon-HE</artifactId>
-            <version>9.7.0-21</version>
+            <version>9.8.0-7</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/src/main/java/com/adobe/epubcheck/xml/XMLValidator.java
+++ b/src/main/java/com/adobe/epubcheck/xml/XMLValidator.java
@@ -174,9 +174,9 @@ public class XMLValidator
     public void initTransformerFactory(TransformerFactory factory)
     {
       super.initTransformerFactory(factory);
-      SymbolicName lineNumberFn = new SymbolicName(StandardNames.XSL_FUNCTION, LineNumberFunction.QNAME, 0);
-      SymbolicName columnNumberFn = new SymbolicName(StandardNames.XSL_FUNCTION, ColumnNumberFunction.QNAME, 0);
-      SymbolicName systemIdFn = new SymbolicName(StandardNames.XSL_FUNCTION, SystemIdFunction.QNAME, 0);
+      SymbolicName.F lineNumberFn = new SymbolicName.F(LineNumberFunction.QNAME, 0);
+      SymbolicName.F columnNumberFn = new SymbolicName.F(ColumnNumberFunction.QNAME, 0);
+      SymbolicName.F systemIdFn = new SymbolicName.F(SystemIdFunction.QNAME, 0);
       if (factory instanceof TransformerFactoryImpl)
       {
         Configuration configuration = ((TransformerFactoryImpl) factory).getConfiguration();


### PR DESCRIPTION
As @raducoravu mentioned in https://github.com/IDPF/epubcheck/issues/674#issuecomment-364250337, Saxon 9.8.0-7 HE supports XSLT 1.0 again. So I've made some minor changes to `XMLValidator.java` related to some API differences between Saxon 9.7 and 9.8. All tests have been passed.