### PR TITLE
[fix #832] update Google Guava dependency to v24.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -205,7 +205,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>24.0-jre</version>
+            <version>24.0-android</version>
         </dependency>
         <dependency>
             <groupId>com.twelvemonkeys.imageio</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -205,7 +205,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>14.0.1</version>
+            <version>24.0-jre</version>
         </dependency>
         <dependency>
             <groupId>com.twelvemonkeys.imageio</groupId>

--- a/src/main/java/org/idpf/epubcheck/util/css/CssEscape.java
+++ b/src/main/java/org/idpf/epubcheck/util/css/CssEscape.java
@@ -21,17 +21,20 @@
  */
 package org.idpf.epubcheck.util.css;
 
-import com.google.common.base.CharMatcher;
-import com.google.common.base.Objects;
-import com.google.common.base.Optional;
-import org.idpf.epubcheck.util.css.CssExceptions.CssException;
-import org.idpf.epubcheck.util.css.CssToken.TokenBuilder;
+import static com.google.common.base.Preconditions.checkArgument;
+import static org.idpf.epubcheck.util.css.CssExceptions.CssErrorCode.SCANNER_PREMATURE_EOF;
+import static org.idpf.epubcheck.util.css.CssScanner.HEXCHAR;
+import static org.idpf.epubcheck.util.css.CssScanner.WHITESPACE;
+import static org.idpf.epubcheck.util.css.CssScanner.isNewLine;
 
 import java.io.IOException;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static org.idpf.epubcheck.util.css.CssExceptions.CssErrorCode.SCANNER_PREMATURE_EOF;
-import static org.idpf.epubcheck.util.css.CssScanner.*;
+import org.idpf.epubcheck.util.css.CssExceptions.CssException;
+import org.idpf.epubcheck.util.css.CssToken.TokenBuilder;
+
+import com.google.common.base.CharMatcher;
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Optional;
 
 /**
  * Represents a CSS escape sequence.
@@ -190,7 +193,7 @@ class CssEscape
   @Override
   public String toString()
   {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
         .add("escaped", sequence)
         .add("unescaped", (char) character)
         .toString();

--- a/src/main/java/org/idpf/epubcheck/util/css/CssExceptions.java
+++ b/src/main/java/org/idpf/epubcheck/util/css/CssExceptions.java
@@ -22,10 +22,10 @@
 
 package org.idpf.epubcheck.util.css;
 
-import com.google.common.base.Objects;
-import com.google.common.base.Optional;
-
 import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Optional;
 
 /**
  * Exception types and error codes.
@@ -59,7 +59,7 @@ public final class CssExceptions
     @Override
     public String toString()
     {
-      return Objects.toStringHelper(this.getClass()).addValue(value).toString();
+      return MoreObjects.toStringHelper(this.getClass()).addValue(value).toString();
     }
 
   }
@@ -129,7 +129,7 @@ public final class CssExceptions
     @Override
     public String toString()
     {
-      return Objects.toStringHelper(this.getClass())
+      return MoreObjects.toStringHelper(this.getClass())
           .add("errorCode", errorCode)
           .add("location", location.toString())
           .toString();

--- a/src/main/java/org/idpf/epubcheck/util/css/CssGrammar.java
+++ b/src/main/java/org/idpf/epubcheck/util/css/CssGrammar.java
@@ -22,23 +22,39 @@
 
 package org.idpf.epubcheck.util.css;
 
-import com.google.common.base.*;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.idpf.epubcheck.util.css.CssExceptions.CssErrorCode.GRAMMAR_UNEXPECTED_TOKEN;
+import static org.idpf.epubcheck.util.css.CssToken.Matchers.MATCH_ATTRIBUTE_SELECTOR_MATCHERS;
+import static org.idpf.epubcheck.util.css.CssToken.Matchers.MATCH_CLOSEPAREN;
+import static org.idpf.epubcheck.util.css.CssToken.Matchers.MATCH_CLOSESQUAREBRACKET;
+import static org.idpf.epubcheck.util.css.CssToken.Matchers.MATCH_COLON;
+import static org.idpf.epubcheck.util.css.CssToken.Matchers.MATCH_COMBINATOR_CHAR;
+import static org.idpf.epubcheck.util.css.CssToken.Matchers.MATCH_COMMA;
+import static org.idpf.epubcheck.util.css.CssToken.Matchers.MATCH_OPENBRACE;
+import static org.idpf.epubcheck.util.css.CssToken.Matchers.MATCH_OPENPAREN;
+import static org.idpf.epubcheck.util.css.CssToken.Matchers.MATCH_OPENSQUAREBRACKET;
+import static org.idpf.epubcheck.util.css.CssToken.Matchers.MATCH_PIPE;
+import static org.idpf.epubcheck.util.css.CssToken.Matchers.MATCH_STAR;
+import static org.idpf.epubcheck.util.css.CssToken.Matchers.MATCH_STAR_PIPE;
+import static org.idpf.epubcheck.util.css.CssTokenList.Filters.FILTER_NONE;
+
+import java.util.List;
+import java.util.Map;
+
 import org.idpf.epubcheck.util.css.CssExceptions.CssErrorCode;
 import org.idpf.epubcheck.util.css.CssExceptions.CssException;
 import org.idpf.epubcheck.util.css.CssExceptions.CssGrammarException;
 import org.idpf.epubcheck.util.css.CssParser.ContextRestrictions;
 import org.idpf.epubcheck.util.css.CssTokenList.CssTokenIterator;
 
-import java.util.List;
-import java.util.Map;
-
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
-import static org.idpf.epubcheck.util.css.CssExceptions.CssErrorCode.GRAMMAR_UNEXPECTED_TOKEN;
-import static org.idpf.epubcheck.util.css.CssToken.Matchers.*;
-import static org.idpf.epubcheck.util.css.CssTokenList.Filters.FILTER_NONE;
+import com.google.common.base.Ascii;
+import com.google.common.base.Joiner;
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
 
 /**
  * CSS grammar components.
@@ -125,7 +141,7 @@ public class CssGrammar
     @Override
     public String toString()
     {
-      return Objects.toStringHelper(this).addValue(value).toString();
+      return MoreObjects.toStringHelper(this).addValue(value).toString();
     }
 
     @Override
@@ -349,7 +365,7 @@ public class CssGrammar
     @Override
     public String toString()
     {
-      return Objects.toStringHelper(this).addValue(subType.name()).addValue(value).toString();
+      return MoreObjects.toStringHelper(this).addValue(subType.name()).addValue(value).toString();
     }
   }
 
@@ -401,7 +417,7 @@ public class CssGrammar
     @Override
     public String toString()
     {
-      return Objects.toStringHelper(this).addValue(subType.name()).addValue(value).toString();
+      return MoreObjects.toStringHelper(this).addValue(subType.name()).addValue(value).toString();
     }
   }
 
@@ -449,7 +465,7 @@ public class CssGrammar
     @Override
     public String toString()
     {
-      return Objects.toStringHelper(this)
+      return MoreObjects.toStringHelper(this)
           .addValue(type)
           .addValue(name.isPresent() ? name.get() : "")
           .addValue(components.isEmpty() ? "" : Joiner.on(" ").join(components))
@@ -593,7 +609,7 @@ public class CssGrammar
     @Override
     public String toString()
     {
-      return Objects.toStringHelper(this)
+      return MoreObjects.toStringHelper(this)
           .addValue(type)
           .addValue(subType)
           .addValue(Joiner.on(" ").join(components))
@@ -659,7 +675,7 @@ public class CssGrammar
     @Override
     public String toString()
     {
-      return Objects.toStringHelper(this)
+      return MoreObjects.toStringHelper(this)
           .addValue(getSubType().name())
           .addValue(getName().get())
           .addValue(function != null ? Joiner.on(" ").join(function.components) : "")

--- a/src/main/java/org/idpf/epubcheck/util/css/CssLocation.java
+++ b/src/main/java/org/idpf/epubcheck/util/css/CssLocation.java
@@ -22,9 +22,9 @@
 
 package org.idpf.epubcheck.util.css;
 
-import com.google.common.base.Objects;
-
 import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.base.MoreObjects;
 
 /**
  * Represents a location in a CSS file.
@@ -75,7 +75,7 @@ public final class CssLocation
   @Override
   public String toString()
   {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
         .add("line", line)
         .add("col", col)
         .add("charOffset", charOffset)

--- a/src/main/java/org/idpf/epubcheck/util/css/CssReader.java
+++ b/src/main/java/org/idpf/epubcheck/util/css/CssReader.java
@@ -21,17 +21,19 @@
  */
 package org.idpf.epubcheck.util.css;
 
-import com.google.common.base.CharMatcher;
-import com.google.common.base.Objects;
-import com.google.common.collect.Lists;
-import com.google.common.primitives.Ints;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.Reader;
 import java.util.List;
 
-import static com.google.common.base.Preconditions.*;
+import com.google.common.base.CharMatcher;
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.Lists;
+import com.google.common.primitives.Ints;
 
 /**
  * A wrapper around java.io.Reader with a pushback buffer, offset and
@@ -380,7 +382,7 @@ final class CssReader
   @Override
   public String toString()
   {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
         .add("curChar", (char) curChar)
         .add("prevChar", (char) prevChar)
         .toString();

--- a/src/main/java/org/idpf/epubcheck/util/css/CssSource.java
+++ b/src/main/java/org/idpf/epubcheck/util/css/CssSource.java
@@ -21,12 +21,17 @@
  */
 package org.idpf.epubcheck.util.css;
 
-import java.io.UnsupportedEncodingException;
-import com.google.common.base.Objects;
-
-import java.io.*;
-
 import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.UnsupportedEncodingException;
+
+import com.google.common.base.MoreObjects;
 
 /**
  * Represents a CSS source.
@@ -86,7 +91,7 @@ public class CssSource
   @Override
   public String toString()
   {
-    return Objects.toStringHelper(this).addValue(systemID).toString();
+    return MoreObjects.toStringHelper(this).addValue(systemID).toString();
   }
 
   @Override

--- a/src/main/java/org/idpf/epubcheck/util/css/CssToken.java
+++ b/src/main/java/org/idpf/epubcheck/util/css/CssToken.java
@@ -21,16 +21,21 @@
  */
 package org.idpf.epubcheck.util.css;
 
-import com.google.common.base.*;
-import com.google.common.collect.Lists;
-import org.idpf.epubcheck.util.css.CssExceptions.CssErrorCode;
-import org.idpf.epubcheck.util.css.CssExceptions.CssException;
-import org.idpf.epubcheck.util.css.CssExceptions.CssScannerException;
+import static com.google.common.base.Preconditions.checkState;
 
 import java.util.Iterator;
 import java.util.List;
 
-import static com.google.common.base.Preconditions.checkState;
+import org.idpf.epubcheck.util.css.CssExceptions.CssErrorCode;
+import org.idpf.epubcheck.util.css.CssExceptions.CssException;
+import org.idpf.epubcheck.util.css.CssExceptions.CssScannerException;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
+import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
 
 /**
  * Represents a CSS token.
@@ -111,7 +116,7 @@ final class CssToken
   @Override
   public String toString()
   {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
         .add("type", type.name())
         .add("value", chars)
         .add("errors", errors.isPresent() ? Joiner.on(", ").join(errors.get()) : "none")


### PR DESCRIPTION
This is a first attempt to updating Google Guava dependency to v24.0 as suggested by @rdeltour in #832.

However, there seem to be compile issues with Maven, despite Eclipse doesn't report any errors.